### PR TITLE
Phase A: Extract DTOs from facade into top-level domain classes

### DIFF
--- a/force-app/main/default/classes/DonationAcknowledgementService.cls
+++ b/force-app/main/default/classes/DonationAcknowledgementService.cls
@@ -47,202 +47,6 @@ public with sharing class DonationAcknowledgementService {
     public Boolean isFailed;
   }
 
-  // Enum for acknowledgement status codes
-  public enum AckStatus {
-    SUCCESS,
-    ALREADY_ACKNOWLEDGED,
-    NO_CONTACT,
-    NO_EMAIL,
-    EMAIL_SEND_FAILED,
-    INVALID_OPPORTUNITY
-  }
-
-  // Individual opportunity result with detailed tracking
-  // TODO: This is growing in importance, we might want to rename it
-  @TestVisible
-  public class OpportunityResult {
-    @AuraEnabled
-    public Id opportunityId;
-    @AuraEnabled
-    public String opportunityName;
-    @AuraEnabled
-    public AckStatus status;
-    @AuraEnabled
-    public String reason;
-    @AuraEnabled
-    public String contactEmail;
-    @AuraEnabled
-    public Date acknowledgmentDate;
-
-    public OpportunityResult(Id oppId, String oppName) {
-      this.opportunityId = oppId;
-      this.opportunityName = oppName;
-    }
-
-    public void setStatus(AckStatus status, String reason) {
-      this.status = status;
-      this.reason = reason;
-    }
-
-    public Boolean isSuccess() {
-      return this.status == AckStatus.SUCCESS;
-    }
-
-    public Boolean isSkipped() {
-      return this.status == AckStatus.ALREADY_ACKNOWLEDGED ||
-        this.status == AckStatus.NO_CONTACT ||
-        this.status == AckStatus.NO_EMAIL;
-    }
-
-    public Boolean isFailed() {
-      return this.status == AckStatus.EMAIL_SEND_FAILED ||
-        this.status == AckStatus.INVALID_OPPORTUNITY;
-    }
-  }
-
-  // Detailed acknowledgement result with individual opportunity tracking
-  @TestVisible
-  public class DetailedAckResult {
-    @AuraEnabled
-    public Integer totalOpportunities;
-    @AuraEnabled
-    public Integer emailsSent;
-    @AuraEnabled
-    public Integer alreadyAcknowledged;
-    @AuraEnabled
-    public Integer noValidContact;
-    @AuraEnabled
-    public Integer emailSendFailures;
-    @AuraEnabled
-    public List<OpportunityResult> opportunityResults;
-    @AuraEnabled
-    public String emailType;
-
-    public DetailedAckResult() {
-      this.totalOpportunities = 0;
-      this.emailsSent = 0;
-      this.alreadyAcknowledged = 0;
-      this.noValidContact = 0;
-      this.emailSendFailures = 0;
-      this.opportunityResults = new List<OpportunityResult>();
-    }
-
-    public void addOpportunityResult(OpportunityResult oppResult) {
-      this.opportunityResults.add(oppResult);
-      this.totalOpportunities++;
-
-      if (oppResult.isSuccess()) {
-        this.emailsSent++;
-      } else if (oppResult.status == AckStatus.ALREADY_ACKNOWLEDGED) {
-        this.alreadyAcknowledged++;
-      } else if (
-        oppResult.status == AckStatus.NO_CONTACT ||
-        oppResult.status == AckStatus.NO_EMAIL
-      ) {
-        this.noValidContact++;
-      } else if (oppResult.status == AckStatus.EMAIL_SEND_FAILED) {
-        this.emailSendFailures++;
-      }
-    }
-
-    public String buildSummaryMessage() {
-      String message =
-        'sendAcknowledgements called with ' +
-        totalOpportunities +
-        ' Opportunities. ';
-      message += 'Emails sent: ' + emailsSent;
-
-      if (alreadyAcknowledged > 0) {
-        message += ', Already acknowledged: ' + alreadyAcknowledged;
-      }
-
-      if (noValidContact > 0) {
-        message += ', No valid contact: ' + noValidContact;
-      }
-
-      if (emailSendFailures > 0) {
-        message += ', Email send failures: ' + emailSendFailures;
-      }
-
-      if (emailType != null) {
-        message += ' (' + emailType + ')';
-      }
-
-      return message;
-    }
-
-    public List<OpportunityResult> getSuccessfulResults() {
-      List<OpportunityResult> successful = new List<OpportunityResult>();
-      for (OpportunityResult result : opportunityResults) {
-        if (result.isSuccess()) {
-          successful.add(result);
-        }
-      }
-      return successful;
-    }
-
-    public List<OpportunityResult> getSkippedResults() {
-      List<OpportunityResult> skipped = new List<OpportunityResult>();
-      for (OpportunityResult result : opportunityResults) {
-        if (result.isSkipped()) {
-          skipped.add(result);
-        }
-      }
-      return skipped;
-    }
-
-    public List<OpportunityResult> getFailedResults() {
-      List<OpportunityResult> failed = new List<OpportunityResult>();
-      for (OpportunityResult result : opportunityResults) {
-        if (result.isFailed()) {
-          failed.add(result);
-        }
-      }
-      return failed;
-    }
-  }
-
-  // Email configuration class to eliminate code duplication
-  @TestVisible
-  public class EmailConfig {
-    public Id templateId;
-    public String subject;
-    public String body;
-    public Boolean useTemplate;
-    public String emailType;
-
-    // Constructor for template-based emails
-    public EmailConfig(Id templateId) {
-      this.templateId = templateId;
-      this.useTemplate = true;
-    }
-
-    // Constructor for static content emails
-    public EmailConfig(String subject, String body) {
-      this.subject = subject;
-      this.body = body;
-      this.useTemplate = false;
-    }
-
-    // Configure a SingleEmailMessage based on this config
-    public void configureEmail(
-      Messaging.SingleEmailMessage mail,
-      Contact contact,
-      Opportunity opp
-    ) {
-      if (useTemplate) {
-        mail.setTemplateId(templateId);
-        mail.setTargetObjectId(contact.Id);
-      } else {
-        mail.setToAddresses(new List<String>{ contact.Email });
-        mail.setSubject(subject);
-        mail.setPlainTextBody(body);
-        mail.setTargetObjectId(contact.Id); // for compliance
-      }
-      mail.setWhatId(opp.Id); // ensures EmailMessage is created and related
-    }
-  }
-
   // Facade delegates to implementation class for business logic
   // Instance variables for template devname and folder are now in implementation class
 
@@ -280,7 +84,7 @@ public with sharing class DonationAcknowledgementService {
   ) {
     List<Id> idList = serviceInstance.extractOpportunityIds(inputList);
     List<DetailedAckResultWrapper> results = new List<DetailedAckResultWrapper>();
-    DetailedAckResult detailedResult = serviceInstance.sendAcknowledgementsDetailed(
+    AckDetailedResult detailedResult = serviceInstance.sendAcknowledgementsDetailed(
       idList
     );
     DetailedAckResultWrapper flowResult = serviceInstance.convertToFlowWrapper(
@@ -297,7 +101,7 @@ public with sharing class DonationAcknowledgementService {
    * @return DetailedAckResult with individual opportunity tracking and aggregated counts
    */
   @AuraEnabled
-  public static DetailedAckResult sendAcknowledgementsDetailed(
+  public static AckDetailedResult sendAcknowledgementsDetailed(
     List<Id> idList
   ) {
     return serviceInstance.sendAcknowledgementsDetailed(idList);
@@ -309,8 +113,10 @@ public with sharing class DonationAcknowledgementService {
    * @return List of OpportunityResult with detailed status and reason for each opportunity
    */
   @AuraEnabled
-  public static List<OpportunityResult> getOpportunityResults(List<Id> idList) {
-    DetailedAckResult detailedResult = serviceInstance.sendAcknowledgementsDetailed(
+  public static List<AckOpportunityResult> getOpportunityResults(
+    List<Id> idList
+  ) {
+    AckDetailedResult detailedResult = serviceInstance.sendAcknowledgementsDetailed(
       idList
     );
     return detailedResult.opportunityResults;

--- a/force-app/main/default/classes/commands/DatabaseUpdateCommand.cls
+++ b/force-app/main/default/classes/commands/DatabaseUpdateCommand.cls
@@ -3,11 +3,11 @@
  * Returns UpdateOutput with update status
  */
 public with sharing class DatabaseUpdateCommand implements IAcknowledgementCommand {
-  private List<DonationAcknowledgementService.OpportunityResult> successfulOpportunities;
+  private List<AckOpportunityResult> successfulOpportunities;
   private AcknowledgementCommandOutputs.UpdateOutput updateOutput;
 
   public DatabaseUpdateCommand(
-    List<DonationAcknowledgementService.OpportunityResult> successfulOpportunities
+    List<AckOpportunityResult> successfulOpportunities
   ) {
     this.successfulOpportunities = successfulOpportunities;
     this.updateOutput = new AcknowledgementCommandOutputs.UpdateOutput();
@@ -26,9 +26,7 @@ public with sharing class DatabaseUpdateCommand implements IAcknowledgementComma
     try {
       List<Opportunity> oppsToUpdate = new List<Opportunity>();
 
-      for (
-        DonationAcknowledgementService.OpportunityResult oppResult : successfulOpportunities
-      ) {
+      for (AckOpportunityResult oppResult : successfulOpportunities) {
         oppsToUpdate.add(
           new Opportunity(
             Id = oppResult.opportunityId,
@@ -48,11 +46,9 @@ public with sharing class DatabaseUpdateCommand implements IAcknowledgementComma
       );
 
       // Mark all opportunities as failed due to database update failure
-      for (
-        DonationAcknowledgementService.OpportunityResult oppResult : successfulOpportunities
-      ) {
+      for (AckOpportunityResult oppResult : successfulOpportunities) {
         oppResult.setStatus(
-          DonationAcknowledgementService.AckStatus.EMAIL_SEND_FAILED,
+          AckStatus.EMAIL_SEND_FAILED,
           'Database update failed: ' + de.getMessage()
         );
       }
@@ -72,11 +68,9 @@ public with sharing class DatabaseUpdateCommand implements IAcknowledgementComma
       );
 
       // Mark all opportunities as failed due to unexpected error
-      for (
-        DonationAcknowledgementService.OpportunityResult oppResult : successfulOpportunities
-      ) {
+      for (AckOpportunityResult oppResult : successfulOpportunities) {
         oppResult.setStatus(
-          DonationAcknowledgementService.AckStatus.EMAIL_SEND_FAILED,
+          AckStatus.EMAIL_SEND_FAILED,
           'Database update error: ' + e.getMessage()
         );
       }

--- a/force-app/main/default/classes/commands/EmailPreparationCommand.cls
+++ b/force-app/main/default/classes/commands/EmailPreparationCommand.cls
@@ -4,7 +4,7 @@
  */
 public with sharing class EmailPreparationCommand implements IAcknowledgementCommand {
   private List<Opportunity> validOpportunities;
-  private DonationAcknowledgementService.EmailConfig config;
+  private AckEmailConfig config;
   private AcknowledgementCommandOutputs.EmailPrepOutput prepOutput;
 
   @testVisible
@@ -12,7 +12,7 @@ public with sharing class EmailPreparationCommand implements IAcknowledgementCom
 
   public EmailPreparationCommand(
     List<Opportunity> validOpportunities,
-    DonationAcknowledgementService.EmailConfig config
+    AckEmailConfig config
   ) {
     this.validOpportunities = validOpportunities;
     this.config = config;
@@ -41,7 +41,7 @@ public with sharing class EmailPreparationCommand implements IAcknowledgementCom
     for (Opportunity opp : validOpportunities) {
       Contact contact = prepOutput.contactMap.get(opp.ContactId);
       if (contact != null) {
-        DonationAcknowledgementService.OpportunityResult oppResult = new DonationAcknowledgementService.OpportunityResult(
+        AckOpportunityResult oppResult = new AckOpportunityResult(
           opp.Id,
           opp.Name
         );

--- a/force-app/main/default/classes/commands/EmailSendCommand.cls
+++ b/force-app/main/default/classes/commands/EmailSendCommand.cls
@@ -4,7 +4,7 @@
  */
 public with sharing class EmailSendCommand implements IAcknowledgementCommand {
   private List<Messaging.SingleEmailMessage> emails;
-  private List<DonationAcknowledgementService.OpportunityResult> opportunityResults;
+  private List<AckOpportunityResult> opportunityResults;
   private AcknowledgementCommandOutputs.SendOutput sendOutput;
 
   // Mutable instance variable for dependency injection
@@ -13,7 +13,7 @@ public with sharing class EmailSendCommand implements IAcknowledgementCommand {
 
   public EmailSendCommand(
     List<Messaging.SingleEmailMessage> emails,
-    List<DonationAcknowledgementService.OpportunityResult> opportunityResults
+    List<AckOpportunityResult> opportunityResults
   ) {
     this.emails = emails;
     this.opportunityResults = opportunityResults;
@@ -26,9 +26,7 @@ public with sharing class EmailSendCommand implements IAcknowledgementCommand {
   public void execute() {
     if (emails.isEmpty()) {
       sendOutput = new AcknowledgementCommandOutputs.SendOutput()
-        .setSuccess(
-          new List<DonationAcknowledgementService.OpportunityResult>()
-        );
+        .setSuccess(new List<AckOpportunityResult>());
       return;
     }
 
@@ -37,13 +35,8 @@ public with sharing class EmailSendCommand implements IAcknowledgementCommand {
 
       // Mark all prepared opportunities as successful
       Date today = Date.today();
-      for (
-        DonationAcknowledgementService.OpportunityResult oppResult : opportunityResults
-      ) {
-        oppResult.setStatus(
-          DonationAcknowledgementService.AckStatus.SUCCESS,
-          'Email sent successfully'
-        );
+      for (AckOpportunityResult oppResult : opportunityResults) {
+        oppResult.setStatus(AckStatus.SUCCESS, 'Email sent successfully');
         oppResult.acknowledgmentDate = today;
       }
 
@@ -56,11 +49,9 @@ public with sharing class EmailSendCommand implements IAcknowledgementCommand {
       );
 
       // Mark all prepared opportunities as failed
-      for (
-        DonationAcknowledgementService.OpportunityResult oppResult : opportunityResults
-      ) {
+      for (AckOpportunityResult oppResult : opportunityResults) {
         oppResult.setStatus(
-          DonationAcknowledgementService.AckStatus.EMAIL_SEND_FAILED,
+          AckStatus.EMAIL_SEND_FAILED,
           'Email sending failed: ' + ee.getMessage()
         );
       }
@@ -81,11 +72,9 @@ public with sharing class EmailSendCommand implements IAcknowledgementCommand {
       );
 
       // Mark all prepared opportunities as failed
-      for (
-        DonationAcknowledgementService.OpportunityResult oppResult : opportunityResults
-      ) {
+      for (AckOpportunityResult oppResult : opportunityResults) {
         oppResult.setStatus(
-          DonationAcknowledgementService.AckStatus.EMAIL_SEND_FAILED,
+          AckStatus.EMAIL_SEND_FAILED,
           'Unexpected error: ' + e.getMessage()
         );
       }

--- a/force-app/main/default/classes/commands/OpportunityValidationCommand.cls
+++ b/force-app/main/default/classes/commands/OpportunityValidationCommand.cls
@@ -4,12 +4,12 @@
  */
 public with sharing class OpportunityValidationCommand implements IAcknowledgementCommand {
   private List<Opportunity> opportunities;
-  private DonationAcknowledgementService.DetailedAckResult result;
+  private AckDetailedResult result;
   private List<Opportunity> validOpportunities;
 
   public OpportunityValidationCommand(
     List<Opportunity> opportunities,
-    DonationAcknowledgementService.DetailedAckResult result
+    AckDetailedResult result
   ) {
     this.opportunities = opportunities;
     this.result = result;
@@ -35,7 +35,7 @@ public with sharing class OpportunityValidationCommand implements IAcknowledgeme
     // Process each opportunity individually with detailed tracking
     for (Opportunity opp : opportunities) {
       // QUESTION: Should OpportunityResult be defined in this class or in DonationAcknowledgementService?
-      DonationAcknowledgementService.OpportunityResult oppResult = new DonationAcknowledgementService.OpportunityResult(
+      AckOpportunityResult oppResult = new AckOpportunityResult(
         opp.Id,
         opp.Name
       );
@@ -43,7 +43,7 @@ public with sharing class OpportunityValidationCommand implements IAcknowledgeme
       // Check if already acknowledged
       if (opp.npsp__Acknowledgment_Date__c != null) {
         oppResult.setStatus(
-          DonationAcknowledgementService.AckStatus.ALREADY_ACKNOWLEDGED,
+          AckStatus.ALREADY_ACKNOWLEDGED,
           'Opportunity already acknowledged on ' +
           opp.npsp__Acknowledgment_Date__c.format()
         );
@@ -58,7 +58,7 @@ public with sharing class OpportunityValidationCommand implements IAcknowledgeme
       // Check if has contact
       if (opp.ContactId == null) {
         oppResult.setStatus(
-          DonationAcknowledgementService.AckStatus.NO_CONTACT,
+          AckStatus.NO_CONTACT,
           'Opportunity has no associated Contact'
         );
         result.addOpportunityResult(oppResult);
@@ -71,10 +71,7 @@ public with sharing class OpportunityValidationCommand implements IAcknowledgeme
 
       Contact contact = contactMap.get(opp.ContactId);
       if (contact == null) {
-        oppResult.setStatus(
-          DonationAcknowledgementService.AckStatus.NO_CONTACT,
-          'Contact not found'
-        );
+        oppResult.setStatus(AckStatus.NO_CONTACT, 'Contact not found');
         result.addOpportunityResult(oppResult);
         System.debug(
           LoggingLevel.WARN,
@@ -85,10 +82,7 @@ public with sharing class OpportunityValidationCommand implements IAcknowledgeme
 
       // Check if contact has email
       if (String.isBlank(contact.Email)) {
-        oppResult.setStatus(
-          DonationAcknowledgementService.AckStatus.NO_EMAIL,
-          'Contact has no email address'
-        );
+        oppResult.setStatus(AckStatus.NO_EMAIL, 'Contact has no email address');
         result.addOpportunityResult(oppResult);
         System.debug(
           LoggingLevel.WARN,

--- a/force-app/main/default/classes/commands/ResultAggregationCommand.cls
+++ b/force-app/main/default/classes/commands/ResultAggregationCommand.cls
@@ -3,14 +3,14 @@
  * Modifies the DetailedAckResult directly - no return value
  */
 public with sharing class ResultAggregationCommand implements IAcknowledgementCommand {
-  private DonationAcknowledgementService.DetailedAckResult result;
+  private AckDetailedResult result;
   private AcknowledgementCommandOutputs.EmailPrepOutput prepOutput;
   private AcknowledgementCommandOutputs.SendOutput sendOutput;
   private AcknowledgementCommandOutputs.UpdateOutput updateOutput;
   private String emailType;
 
   public ResultAggregationCommand(
-    DonationAcknowledgementService.DetailedAckResult result,
+    AckDetailedResult result,
     AcknowledgementCommandOutputs.EmailPrepOutput prepOutput,
     AcknowledgementCommandOutputs.SendOutput sendOutput,
     AcknowledgementCommandOutputs.UpdateOutput updateOutput,
@@ -30,15 +30,13 @@ public with sharing class ResultAggregationCommand implements IAcknowledgementCo
     // Add successful opportunities to result
     if (sendOutput.isSuccess) {
       for (
-        DonationAcknowledgementService.OpportunityResult oppResult : sendOutput.successfulOpportunities
+        AckOpportunityResult oppResult : sendOutput.successfulOpportunities
       ) {
         result.addOpportunityResult(oppResult);
       }
     } else {
       // Add failed opportunities to result
-      for (
-        DonationAcknowledgementService.OpportunityResult oppResult : sendOutput.failedOpportunities
-      ) {
+      for (AckOpportunityResult oppResult : sendOutput.failedOpportunities) {
         result.addOpportunityResult(oppResult);
       }
     }

--- a/force-app/main/default/classes/domain/AckDetailedResult.cls
+++ b/force-app/main/default/classes/domain/AckDetailedResult.cls
@@ -1,0 +1,100 @@
+// Detailed acknowledgement result with individual opportunity tracking
+public with sharing class AckDetailedResult {
+  @AuraEnabled
+  public Integer totalOpportunities;
+  @AuraEnabled
+  public Integer emailsSent;
+  @AuraEnabled
+  public Integer alreadyAcknowledged;
+  @AuraEnabled
+  public Integer noValidContact;
+  @AuraEnabled
+  public Integer emailSendFailures;
+  @AuraEnabled
+  public List<AckOpportunityResult> opportunityResults;
+  @AuraEnabled
+  public String emailType;
+
+  public AckDetailedResult() {
+    this.totalOpportunities = 0;
+    this.emailsSent = 0;
+    this.alreadyAcknowledged = 0;
+    this.noValidContact = 0;
+    this.emailSendFailures = 0;
+    this.opportunityResults = new List<AckOpportunityResult>();
+  }
+
+  public void addOpportunityResult(AckOpportunityResult oppResult) {
+    this.opportunityResults.add(oppResult);
+    this.totalOpportunities++;
+
+    if (oppResult.isSuccess()) {
+      this.emailsSent++;
+    } else if (oppResult.status == AckStatus.ALREADY_ACKNOWLEDGED) {
+      this.alreadyAcknowledged++;
+    } else if (
+      oppResult.status == AckStatus.NO_CONTACT ||
+      oppResult.status == AckStatus.NO_EMAIL
+    ) {
+      this.noValidContact++;
+    } else if (oppResult.status == AckStatus.EMAIL_SEND_FAILED) {
+      this.emailSendFailures++;
+    }
+  }
+
+  public String buildSummaryMessage() {
+    String message =
+      'sendAcknowledgements called with ' +
+      totalOpportunities +
+      ' Opportunities. ';
+    message += 'Emails sent: ' + emailsSent;
+
+    if (alreadyAcknowledged > 0) {
+      message += ', Already acknowledged: ' + alreadyAcknowledged;
+    }
+
+    if (noValidContact > 0) {
+      message += ', No valid contact: ' + noValidContact;
+    }
+
+    if (emailSendFailures > 0) {
+      message += ', Email send failures: ' + emailSendFailures;
+    }
+
+    if (emailType != null) {
+      message += ' (' + emailType + ')';
+    }
+
+    return message;
+  }
+
+  public List<AckOpportunityResult> getSuccessfulResults() {
+    List<AckOpportunityResult> successful = new List<AckOpportunityResult>();
+    for (AckOpportunityResult result : opportunityResults) {
+      if (result.isSuccess()) {
+        successful.add(result);
+      }
+    }
+    return successful;
+  }
+
+  public List<AckOpportunityResult> getSkippedResults() {
+    List<AckOpportunityResult> skipped = new List<AckOpportunityResult>();
+    for (AckOpportunityResult result : opportunityResults) {
+      if (result.isSkipped()) {
+        skipped.add(result);
+      }
+    }
+    return skipped;
+  }
+
+  public List<AckOpportunityResult> getFailedResults() {
+    List<AckOpportunityResult> failed = new List<AckOpportunityResult>();
+    for (AckOpportunityResult result : opportunityResults) {
+      if (result.isFailed()) {
+        failed.add(result);
+      }
+    }
+    return failed;
+  }
+}

--- a/force-app/main/default/classes/domain/AckDetailedResult.cls-meta.xml
+++ b/force-app/main/default/classes/domain/AckDetailedResult.cls-meta.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!-- ApexClass metadata documentation: https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_classes.htm -->
+<ApexClass xmlns="https://soap.sforce.com/2006/04/metadata">
+    <apiVersion>61.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/domain/AckEmailConfig.cls
+++ b/force-app/main/default/classes/domain/AckEmailConfig.cls
@@ -1,0 +1,39 @@
+// Email configuration class to eliminate code duplication
+public with sharing class AckEmailConfig {
+  public Id templateId;
+  public String subject;
+  public String body;
+  public Boolean useTemplate;
+  public String emailType;
+
+  // Constructor for template-based emails
+  public AckEmailConfig(Id templateId) {
+    this.templateId = templateId;
+    this.useTemplate = true;
+  }
+
+  // Constructor for static content emails
+  public AckEmailConfig(String subject, String body) {
+    this.subject = subject;
+    this.body = body;
+    this.useTemplate = false;
+  }
+
+  // Configure a SingleEmailMessage based on this config
+  public void configureEmail(
+    Messaging.SingleEmailMessage mail,
+    Contact contact,
+    Opportunity opp
+  ) {
+    if (useTemplate) {
+      mail.setTemplateId(templateId);
+      mail.setTargetObjectId(contact.Id);
+    } else {
+      mail.setToAddresses(new List<String>{ contact.Email });
+      mail.setSubject(subject);
+      mail.setPlainTextBody(body);
+      mail.setTargetObjectId(contact.Id); // for compliance
+    }
+    mail.setWhatId(opp.Id); // ensures EmailMessage is created and related
+  }
+}

--- a/force-app/main/default/classes/domain/AckEmailConfig.cls-meta.xml
+++ b/force-app/main/default/classes/domain/AckEmailConfig.cls-meta.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!-- ApexClass metadata documentation: https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_classes.htm -->
+<ApexClass xmlns="https://soap.sforce.com/2006/04/metadata">
+    <apiVersion>61.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/domain/AckOpportunityResult.cls
+++ b/force-app/main/default/classes/domain/AckOpportunityResult.cls
@@ -1,0 +1,41 @@
+// Individual opportunity result with detailed tracking
+// TODO: This is growing in importance, we might want to rename it
+public with sharing class AckOpportunityResult {
+  @AuraEnabled
+  public Id opportunityId;
+  @AuraEnabled
+  public String opportunityName;
+  @AuraEnabled
+  public AckStatus status;
+  @AuraEnabled
+  public String reason;
+  @AuraEnabled
+  public String contactEmail;
+  @AuraEnabled
+  public Date acknowledgmentDate;
+
+  public AckOpportunityResult(Id oppId, String oppName) {
+    this.opportunityId = oppId;
+    this.opportunityName = oppName;
+  }
+
+  public void setStatus(AckStatus status, String reason) {
+    this.status = status;
+    this.reason = reason;
+  }
+
+  public Boolean isSuccess() {
+    return this.status == AckStatus.SUCCESS;
+  }
+
+  public Boolean isSkipped() {
+    return this.status == AckStatus.ALREADY_ACKNOWLEDGED ||
+      this.status == AckStatus.NO_CONTACT ||
+      this.status == AckStatus.NO_EMAIL;
+  }
+
+  public Boolean isFailed() {
+    return this.status == AckStatus.EMAIL_SEND_FAILED ||
+      this.status == AckStatus.INVALID_OPPORTUNITY;
+  }
+}

--- a/force-app/main/default/classes/domain/AckOpportunityResult.cls-meta.xml
+++ b/force-app/main/default/classes/domain/AckOpportunityResult.cls-meta.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!-- ApexClass metadata documentation: https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_classes.htm -->
+<ApexClass xmlns="https://soap.sforce.com/2006/04/metadata">
+    <apiVersion>61.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/domain/AckStatus.cls
+++ b/force-app/main/default/classes/domain/AckStatus.cls
@@ -1,0 +1,9 @@
+// Enum for acknowledgement status codes
+public enum AckStatus {
+  SUCCESS,
+  ALREADY_ACKNOWLEDGED,
+  NO_CONTACT,
+  NO_EMAIL,
+  EMAIL_SEND_FAILED,
+  INVALID_OPPORTUNITY
+}

--- a/force-app/main/default/classes/domain/AckStatus.cls-meta.xml
+++ b/force-app/main/default/classes/domain/AckStatus.cls-meta.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!-- ApexClass metadata documentation: https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_classes.htm -->
+<ApexClass xmlns="https://soap.sforce.com/2006/04/metadata">
+    <apiVersion>61.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/outputs/AcknowledgementCommandOutputs.cls
+++ b/force-app/main/default/classes/outputs/AcknowledgementCommandOutputs.cls
@@ -9,12 +9,12 @@ public with sharing class AcknowledgementCommandOutputs {
   public class EmailPrepOutput {
     public List<Messaging.SingleEmailMessage> emails;
     public Map<Id, Contact> contactMap;
-    public List<DonationAcknowledgementService.OpportunityResult> validOpportunities;
+    public List<AckOpportunityResult> validOpportunities;
 
     public EmailPrepOutput() {
       this.emails = new List<Messaging.SingleEmailMessage>();
       this.contactMap = new Map<Id, Contact>();
-      this.validOpportunities = new List<DonationAcknowledgementService.OpportunityResult>();
+      this.validOpportunities = new List<AckOpportunityResult>();
     }
   }
 
@@ -24,18 +24,16 @@ public with sharing class AcknowledgementCommandOutputs {
   public class SendOutput {
     public Boolean isSuccess;
     public String errorMessage;
-    public List<DonationAcknowledgementService.OpportunityResult> successfulOpportunities;
-    public List<DonationAcknowledgementService.OpportunityResult> failedOpportunities;
+    public List<AckOpportunityResult> successfulOpportunities;
+    public List<AckOpportunityResult> failedOpportunities;
 
     public SendOutput() {
       this.isSuccess = false;
-      this.successfulOpportunities = new List<DonationAcknowledgementService.OpportunityResult>();
-      this.failedOpportunities = new List<DonationAcknowledgementService.OpportunityResult>();
+      this.successfulOpportunities = new List<AckOpportunityResult>();
+      this.failedOpportunities = new List<AckOpportunityResult>();
     }
 
-    public SendOutput setSuccess(
-      List<DonationAcknowledgementService.OpportunityResult> successfulOpps
-    ) {
+    public SendOutput setSuccess(List<AckOpportunityResult> successfulOpps) {
       this.isSuccess = true;
       this.successfulOpportunities = successfulOpps;
       return this;
@@ -43,7 +41,7 @@ public with sharing class AcknowledgementCommandOutputs {
 
     public SendOutput setFailure(
       String errorMessage,
-      List<DonationAcknowledgementService.OpportunityResult> failedOpps
+      List<AckOpportunityResult> failedOpps
     ) {
       this.isSuccess = false;
       this.errorMessage = errorMessage;

--- a/force-app/main/default/classes/services/DonationAcknowledgementServiceImpl.cls
+++ b/force-app/main/default/classes/services/DonationAcknowledgementServiceImpl.cls
@@ -72,7 +72,7 @@ public with sharing class DonationAcknowledgementServiceImpl {
    * Convert DetailedAckResult to Flow-compatible DetailedAckResultWrapper
    */
   public DonationAcknowledgementService.DetailedAckResultWrapper convertToFlowWrapper(
-    DonationAcknowledgementService.DetailedAckResult detailedResult
+    AckDetailedResult detailedResult
   ) {
     DonationAcknowledgementService.DetailedAckResultWrapper flowResult = new DonationAcknowledgementService.DetailedAckResultWrapper();
 
@@ -87,9 +87,7 @@ public with sharing class DonationAcknowledgementServiceImpl {
 
     // Convert individual opportunity results
     flowResult.opportunityDetails = new List<DonationAcknowledgementService.OpportunityResultWrapper>();
-    for (
-      DonationAcknowledgementService.OpportunityResult oppResult : detailedResult.opportunityResults
-    ) {
+    for (AckOpportunityResult oppResult : detailedResult.opportunityResults) {
       DonationAcknowledgementService.OpportunityResultWrapper flowOppResult = new DonationAcknowledgementService.OpportunityResultWrapper();
       flowOppResult.opportunityId = String.valueOf(oppResult.opportunityId);
       flowOppResult.opportunityName = oppResult.opportunityName;
@@ -114,17 +112,15 @@ public with sharing class DonationAcknowledgementServiceImpl {
    * @param idList List of Opportunity IDs to process
    * @return DetailedAckResult with individual opportunity tracking and aggregated counts
    */
-  public DonationAcknowledgementService.DetailedAckResult sendAcknowledgementsDetailed(
-    List<Id> idList
-  ) {
+  public AckDetailedResult sendAcknowledgementsDetailed(List<Id> idList) {
     List<Opportunity> opps = getOpportunitiesByIds(idList);
     if (opps.isEmpty()) {
-      DonationAcknowledgementService.DetailedAckResult emptyResult = new DonationAcknowledgementService.DetailedAckResult();
+      AckDetailedResult emptyResult = new AckDetailedResult();
       emptyResult.emailType = 'No opportunities provided';
       return emptyResult;
     }
-    DonationAcknowledgementService.DetailedAckResult result;
-    DonationAcknowledgementService.EmailConfig config = getEmailConfiguration();
+    AckDetailedResult result;
+    AckEmailConfig config = getEmailConfiguration();
     result = sendEmailsCoreDetailed(opps, config);
     result.emailType = config.emailType;
     return result;
@@ -136,11 +132,11 @@ public with sharing class DonationAcknowledgementServiceImpl {
    * Now implemented using Command pattern for better separation of concerns.
    */
   @TestVisible
-  public DonationAcknowledgementService.DetailedAckResult sendEmailsCoreDetailed(
+  public AckDetailedResult sendEmailsCoreDetailed(
     List<Opportunity> opps,
-    DonationAcknowledgementService.EmailConfig config
+    AckEmailConfig config
   ) {
-    DonationAcknowledgementService.DetailedAckResult detailedResult = new DonationAcknowledgementService.DetailedAckResult();
+    AckDetailedResult detailedResult = new AckDetailedResult();
 
     // Command orchestration - each command handles a specific responsibility
 
@@ -206,7 +202,7 @@ public with sharing class DonationAcknowledgementServiceImpl {
    * Get email configuration with proper exception handling for template lookup
    * @return EmailConfig configured with template or static fallback
    */
-  private DonationAcknowledgementService.EmailConfig getEmailConfiguration() {
+  private AckEmailConfig getEmailConfiguration() {
     try {
       EmailTemplate tmpl = [
         SELECT Id
@@ -216,9 +212,7 @@ public with sharing class DonationAcknowledgementServiceImpl {
           AND Folder.DeveloperName = :donationAckTemplateFolder
         LIMIT 1
       ];
-      DonationAcknowledgementService.EmailConfig config = new DonationAcknowledgementService.EmailConfig(
-        tmpl.Id
-      );
+      AckEmailConfig config = new AckEmailConfig(tmpl.Id);
       config.emailType = 'Template used: ' + donationAckTemplateDevName;
       return config;
     } catch (QueryException qe) {
@@ -240,13 +234,10 @@ public with sharing class DonationAcknowledgementServiceImpl {
    * Get static email configuration as fallback
    * @return EmailConfig with static content
    */
-  private DonationAcknowledgementService.EmailConfig getStaticEmailConfiguration() {
+  private AckEmailConfig getStaticEmailConfiguration() {
     String subject = 'Thank you for your donation!';
     String body = 'We appreciate your generous support.';
-    DonationAcknowledgementService.EmailConfig config = new DonationAcknowledgementService.EmailConfig(
-      subject,
-      body
-    );
+    AckEmailConfig config = new AckEmailConfig(subject, body);
     config.emailType = 'Static content fallback';
     return config;
   }

--- a/force-app/main/default/classes/tests/DonationAcknowledgementServiceTest.cls
+++ b/force-app/main/default/classes/tests/DonationAcknowledgementServiceTest.cls
@@ -149,7 +149,7 @@ private class DonationAcknowledgementServiceTest {
 
     Test.startTest();
     try {
-      DonationAcknowledgementService.DetailedAckResult result = DonationAcknowledgementService.sendAcknowledgementsDetailed(
+      AckDetailedResult result = DonationAcknowledgementService.sendAcknowledgementsDetailed(
         oppIds
       );
       // If we get here, email sending succeeded (normal test behavior)
@@ -203,7 +203,7 @@ private class DonationAcknowledgementServiceTest {
     Test.startTest();
     AcknowledgementTestUtils.injectServiceWithMockEmail();
 
-    DonationAcknowledgementService.DetailedAckResult result = DonationAcknowledgementService.sendAcknowledgementsDetailed(
+    AckDetailedResult result = DonationAcknowledgementService.sendAcknowledgementsDetailed(
       oppIds
     );
 
@@ -260,7 +260,7 @@ private class DonationAcknowledgementServiceTest {
     List<Id> oppIds = new List<Id>{ acknowledgedOpp.Id };
 
     Test.startTest();
-    DonationAcknowledgementService.DetailedAckResult result = DonationAcknowledgementService.sendAcknowledgementsDetailed(
+    AckDetailedResult result = DonationAcknowledgementService.sendAcknowledgementsDetailed(
       oppIds
     );
     Test.stopTest();
@@ -285,7 +285,7 @@ private class DonationAcknowledgementServiceTest {
     Id testOppId = '006000000000001AAA'; // Mock opportunity ID
     String testOppName = 'Test Opportunity';
 
-    DonationAcknowledgementService.OpportunityResult oppResult = new DonationAcknowledgementService.OpportunityResult(
+    AckOpportunityResult oppResult = new AckOpportunityResult(
       testOppId,
       testOppName
     );
@@ -302,12 +302,9 @@ private class DonationAcknowledgementServiceTest {
     );
 
     // Test setting success status
-    oppResult.setStatus(
-      DonationAcknowledgementService.AckStatus.SUCCESS,
-      'Email sent successfully'
-    );
+    oppResult.setStatus(AckStatus.SUCCESS, 'Email sent successfully');
     System.assertEquals(
-      DonationAcknowledgementService.AckStatus.SUCCESS,
+      AckStatus.SUCCESS,
       oppResult.status,
       'Should set success status'
     );
@@ -321,19 +318,13 @@ private class DonationAcknowledgementServiceTest {
     System.assert(!oppResult.isFailed(), 'Should not identify as failed');
 
     // Test setting skipped status
-    oppResult.setStatus(
-      DonationAcknowledgementService.AckStatus.ALREADY_ACKNOWLEDGED,
-      'Already acknowledged'
-    );
+    oppResult.setStatus(AckStatus.ALREADY_ACKNOWLEDGED, 'Already acknowledged');
     System.assert(!oppResult.isSuccess(), 'Should not identify as success');
     System.assert(oppResult.isSkipped(), 'Should identify as skipped');
     System.assert(!oppResult.isFailed(), 'Should not identify as failed');
 
     // Test setting failed status
-    oppResult.setStatus(
-      DonationAcknowledgementService.AckStatus.EMAIL_SEND_FAILED,
-      'Send failed'
-    );
+    oppResult.setStatus(AckStatus.EMAIL_SEND_FAILED, 'Send failed');
     System.assert(!oppResult.isSuccess(), 'Should not identify as success');
     System.assert(!oppResult.isSkipped(), 'Should not identify as skipped');
     System.assert(oppResult.isFailed(), 'Should identify as failed');
@@ -342,44 +333,35 @@ private class DonationAcknowledgementServiceTest {
   @isTest
   static void testDetailedAckResultAggregation() {
     // Test DetailedAckResult class functionality
-    DonationAcknowledgementService.DetailedAckResult detailedResult = new DonationAcknowledgementService.DetailedAckResult();
+    AckDetailedResult detailedResult = new AckDetailedResult();
 
     // Create various OpportunityResults to test aggregation
-    DonationAcknowledgementService.OpportunityResult successResult = new DonationAcknowledgementService.OpportunityResult(
+    AckOpportunityResult successResult = new AckOpportunityResult(
       '006000000000001AAA',
       'Success Opp'
     );
-    successResult.setStatus(
-      DonationAcknowledgementService.AckStatus.SUCCESS,
-      'Email sent'
-    );
+    successResult.setStatus(AckStatus.SUCCESS, 'Email sent');
 
-    DonationAcknowledgementService.OpportunityResult acknowledgedResult = new DonationAcknowledgementService.OpportunityResult(
+    AckOpportunityResult acknowledgedResult = new AckOpportunityResult(
       '006000000000002AAA',
       'Acknowledged Opp'
     );
     acknowledgedResult.setStatus(
-      DonationAcknowledgementService.AckStatus.ALREADY_ACKNOWLEDGED,
+      AckStatus.ALREADY_ACKNOWLEDGED,
       'Already done'
     );
 
-    DonationAcknowledgementService.OpportunityResult noContactResult = new DonationAcknowledgementService.OpportunityResult(
+    AckOpportunityResult noContactResult = new AckOpportunityResult(
       '006000000000003AAA',
       'No Contact Opp'
     );
-    noContactResult.setStatus(
-      DonationAcknowledgementService.AckStatus.NO_CONTACT,
-      'No contact'
-    );
+    noContactResult.setStatus(AckStatus.NO_CONTACT, 'No contact');
 
-    DonationAcknowledgementService.OpportunityResult failedResult = new DonationAcknowledgementService.OpportunityResult(
+    AckOpportunityResult failedResult = new AckOpportunityResult(
       '006000000000004AAA',
       'Failed Opp'
     );
-    failedResult.setStatus(
-      DonationAcknowledgementService.AckStatus.EMAIL_SEND_FAILED,
-      'Send failed'
-    );
+    failedResult.setStatus(AckStatus.EMAIL_SEND_FAILED, 'Send failed');
 
     // Add results and verify aggregation
     detailedResult.addOpportunityResult(successResult);
@@ -414,7 +396,7 @@ private class DonationAcknowledgementServiceTest {
     );
 
     // Test filtering methods
-    List<DonationAcknowledgementService.OpportunityResult> successful = detailedResult.getSuccessfulResults();
+    List<AckOpportunityResult> successful = detailedResult.getSuccessfulResults();
     System.assertEquals(
       1,
       successful.size(),
@@ -426,10 +408,10 @@ private class DonationAcknowledgementServiceTest {
       'Should be the success opportunity'
     );
 
-    List<DonationAcknowledgementService.OpportunityResult> skipped = detailedResult.getSkippedResults();
+    List<AckOpportunityResult> skipped = detailedResult.getSkippedResults();
     System.assertEquals(2, skipped.size(), 'Should have 2 skipped results');
 
-    List<DonationAcknowledgementService.OpportunityResult> failed = detailedResult.getFailedResults();
+    List<AckOpportunityResult> failed = detailedResult.getFailedResults();
     System.assertEquals(1, failed.size(), 'Should have 1 failed result');
     System.assertEquals(
       'Failed Opp',
@@ -488,18 +470,12 @@ private class DonationAcknowledgementServiceTest {
       new List<Id>{ opp1.Id, opp2.Id }
     );
 
-    DonationAcknowledgementService.EmailConfig config = new DonationAcknowledgementService.EmailConfig(
-      'Test Subject',
-      'Test Body'
-    );
+    AckEmailConfig config = new AckEmailConfig('Test Subject', 'Test Body');
 
     Test.startTest();
     DonationAcknowledgementServiceImpl service = AcknowledgementTestUtils.createConfiguredServiceWithMockEmail();
 
-    DonationAcknowledgementService.DetailedAckResult result = service.sendEmailsCoreDetailed(
-      opps,
-      config
-    );
+    AckDetailedResult result = service.sendEmailsCoreDetailed(opps, config);
 
     AcknowledgementTestUtils.resetServiceInstance();
     Test.stopTest();
@@ -514,11 +490,9 @@ private class DonationAcknowledgementServiceTest {
       'Should have 2 opportunity results'
     );
 
-    for (
-      DonationAcknowledgementService.OpportunityResult oppResult : result.opportunityResults
-    ) {
+    for (AckOpportunityResult oppResult : result.opportunityResults) {
       System.assertEquals(
-        DonationAcknowledgementService.AckStatus.SUCCESS,
+        AckStatus.SUCCESS,
         oppResult.status,
         'Should be successful'
       );
@@ -589,20 +563,14 @@ private class DonationAcknowledgementServiceTest {
         noEmailOpp.Id
       }
     );
-    DonationAcknowledgementService.EmailConfig config = new DonationAcknowledgementService.EmailConfig(
-      'Test Subject',
-      'Test Body'
-    );
+    AckEmailConfig config = new AckEmailConfig('Test Subject', 'Test Body');
     // Instance-based: create and configure service with mock email
     DonationAcknowledgementServiceImpl service = AcknowledgementTestUtils.createConfiguredServiceWithMockEmail();
     Test.startTest();
-    DonationAcknowledgementService.DetailedAckResult result = service.sendEmailsCoreDetailed(
-      opps,
-      config
-    );
+    AckDetailedResult result = service.sendEmailsCoreDetailed(opps, config);
     Test.stopTest();
     AcknowledgementTestUtils.assertDetailedResultCounts(result, 4, 1, 1, 2, 0);
-    List<DonationAcknowledgementService.OpportunityResult> successfulResults = result.getSuccessfulResults();
+    List<AckOpportunityResult> successfulResults = result.getSuccessfulResults();
     System.assertEquals(
       1,
       successfulResults.size(),
@@ -613,30 +581,12 @@ private class DonationAcknowledgementServiceTest {
   @isTest
   static void testAckStatusEnumValues() {
     // Test that all expected enum values exist
-    System.assertNotEquals(
-      null,
-      DonationAcknowledgementService.AckStatus.SUCCESS
-    );
-    System.assertNotEquals(
-      null,
-      DonationAcknowledgementService.AckStatus.ALREADY_ACKNOWLEDGED
-    );
-    System.assertNotEquals(
-      null,
-      DonationAcknowledgementService.AckStatus.NO_CONTACT
-    );
-    System.assertNotEquals(
-      null,
-      DonationAcknowledgementService.AckStatus.NO_EMAIL
-    );
-    System.assertNotEquals(
-      null,
-      DonationAcknowledgementService.AckStatus.EMAIL_SEND_FAILED
-    );
-    System.assertNotEquals(
-      null,
-      DonationAcknowledgementService.AckStatus.INVALID_OPPORTUNITY
-    );
+    System.assertNotEquals(null, AckStatus.SUCCESS);
+    System.assertNotEquals(null, AckStatus.ALREADY_ACKNOWLEDGED);
+    System.assertNotEquals(null, AckStatus.NO_CONTACT);
+    System.assertNotEquals(null, AckStatus.NO_EMAIL);
+    System.assertNotEquals(null, AckStatus.EMAIL_SEND_FAILED);
+    System.assertNotEquals(null, AckStatus.INVALID_OPPORTUNITY);
   }
 
   @isTest
@@ -648,7 +598,7 @@ private class DonationAcknowledgementServiceTest {
     Test.startTest();
     AcknowledgementTestUtils.injectServiceWithMockEmail();
 
-    DonationAcknowledgementService.DetailedAckResult result = DonationAcknowledgementService.sendAcknowledgementsDetailed(
+    AckDetailedResult result = DonationAcknowledgementService.sendAcknowledgementsDetailed(
       oppIds
     );
 
@@ -668,14 +618,14 @@ private class DonationAcknowledgementServiceTest {
       result.opportunityResults.size(),
       'Should have 1 opportunity result'
     );
-    DonationAcknowledgementService.OpportunityResult oppResult = result.opportunityResults[0];
+    AckOpportunityResult oppResult = result.opportunityResults[0];
     System.assertEquals(
       opp.Id,
       oppResult.opportunityId,
       'Should have correct opportunity ID'
     );
     System.assertEquals(
-      DonationAcknowledgementService.AckStatus.SUCCESS,
+      AckStatus.SUCCESS,
       oppResult.status,
       'Should be successful'
     );
@@ -711,7 +661,7 @@ private class DonationAcknowledgementServiceTest {
       List<Id> oppIds = new List<Id>{ opp.Id };
 
       Test.startTest();
-      DonationAcknowledgementService.DetailedAckResult result = DonationAcknowledgementService.sendAcknowledgementsDetailed(
+      AckDetailedResult result = DonationAcknowledgementService.sendAcknowledgementsDetailed(
         oppIds
       );
       Test.stopTest();
@@ -736,9 +686,9 @@ private class DonationAcknowledgementServiceTest {
         result.opportunityResults.size(),
         'Should have 1 opportunity result'
       );
-      DonationAcknowledgementService.OpportunityResult oppResult = result.opportunityResults[0];
+      AckOpportunityResult oppResult = result.opportunityResults[0];
       System.assertEquals(
-        DonationAcknowledgementService.AckStatus.SUCCESS,
+        AckStatus.SUCCESS,
         oppResult.status,
         'Should be successful'
       );
@@ -753,7 +703,7 @@ private class DonationAcknowledgementServiceTest {
     List<Id> emptyIds = new List<Id>();
 
     Test.startTest();
-    DonationAcknowledgementService.DetailedAckResult result = DonationAcknowledgementService.sendAcknowledgementsDetailed(
+    AckDetailedResult result = DonationAcknowledgementService.sendAcknowledgementsDetailed(
       emptyIds
     );
     Test.stopTest();
@@ -796,7 +746,7 @@ private class DonationAcknowledgementServiceTest {
     Test.startTest();
     AcknowledgementTestUtils.injectServiceWithMockEmail();
 
-    List<DonationAcknowledgementService.OpportunityResult> results = DonationAcknowledgementService.getOpportunityResults(
+    List<AckOpportunityResult> results = DonationAcknowledgementService.getOpportunityResults(
       oppIds
     );
 
@@ -807,7 +757,7 @@ private class DonationAcknowledgementServiceTest {
     System.assertEquals(2, results.size(), 'Should have 2 opportunity results');
 
     // Find results by opportunity name using helper
-    Map<String, DonationAcknowledgementService.OpportunityResult> resultsByName = AcknowledgementTestUtils.createResultsByNameMap(
+    Map<String, AckOpportunityResult> resultsByName = AcknowledgementTestUtils.createResultsByNameMap(
       results
     );
 
@@ -815,20 +765,18 @@ private class DonationAcknowledgementServiceTest {
     AcknowledgementTestUtils.assertOpportunityResult(
       resultsByName,
       'Success Opp',
-      DonationAcknowledgementService.AckStatus.SUCCESS,
+      AckStatus.SUCCESS,
       'Email sent successfully'
     );
 
-    DonationAcknowledgementService.OpportunityResult successResult = resultsByName.get(
-      'Success Opp'
-    );
+    AckOpportunityResult successResult = resultsByName.get('Success Opp');
     System.assertEquals('testuser@example.com', successResult.contactEmail);
 
     // Verify already acknowledged opportunity
     AcknowledgementTestUtils.assertOpportunityResult(
       resultsByName,
       'Already Acknowledged Opp',
-      DonationAcknowledgementService.AckStatus.ALREADY_ACKNOWLEDGED,
+      AckStatus.ALREADY_ACKNOWLEDGED,
       'already acknowledged'
     );
   }
@@ -843,7 +791,7 @@ private class DonationAcknowledgementServiceTest {
     AcknowledgementTestUtils.injectServiceWithMockEmail();
 
     // Call detailed method
-    DonationAcknowledgementService.DetailedAckResult detailedResult = DonationAcknowledgementService.sendAcknowledgementsDetailed(
+    AckDetailedResult detailedResult = DonationAcknowledgementService.sendAcknowledgementsDetailed(
       oppIds
     );
 

--- a/force-app/main/default/classes/tests/commands/DatabaseUpdateCommandTest.cls
+++ b/force-app/main/default/classes/tests/commands/DatabaseUpdateCommandTest.cls
@@ -24,13 +24,10 @@ private class DatabaseUpdateCommandTest {
     Opportunity opp = [SELECT Id, Name FROM Opportunity LIMIT 1];
 
     // Create successful opportunity result
-    DonationAcknowledgementService.OpportunityResult oppResult = new DonationAcknowledgementService.OpportunityResult(
-      opp.Id,
-      opp.Name
-    );
+    AckOpportunityResult oppResult = new AckOpportunityResult(opp.Id, opp.Name);
     oppResult.acknowledgmentDate = Date.today();
 
-    List<DonationAcknowledgementService.OpportunityResult> successfulOpps = new List<DonationAcknowledgementService.OpportunityResult>{
+    List<AckOpportunityResult> successfulOpps = new List<AckOpportunityResult>{
       oppResult
     };
 
@@ -72,7 +69,7 @@ private class DatabaseUpdateCommandTest {
     Contact c = [SELECT Id FROM Contact LIMIT 1];
 
     List<Id> oppIds = new List<Id>();
-    List<DonationAcknowledgementService.OpportunityResult> successfulOpps = new List<DonationAcknowledgementService.OpportunityResult>();
+    List<AckOpportunityResult> successfulOpps = new List<AckOpportunityResult>();
 
     // Create multiple opportunities and results
     for (Integer i = 1; i <= 3; i++) {
@@ -84,7 +81,7 @@ private class DatabaseUpdateCommandTest {
       );
       oppIds.add(opp.Id);
 
-      DonationAcknowledgementService.OpportunityResult oppResult = new DonationAcknowledgementService.OpportunityResult(
+      AckOpportunityResult oppResult = new AckOpportunityResult(
         opp.Id,
         'Update Test Opp ' + i
       );
@@ -135,7 +132,7 @@ private class DatabaseUpdateCommandTest {
   @isTest
   static void testUpdateDatabaseEmptyList() {
     // Test database update with empty opportunity list
-    List<DonationAcknowledgementService.OpportunityResult> emptyOpps = new List<DonationAcknowledgementService.OpportunityResult>();
+    List<AckOpportunityResult> emptyOpps = new List<AckOpportunityResult>();
 
     Test.startTest();
     DatabaseUpdateCommand updateCmd = new DatabaseUpdateCommand(emptyOpps);
@@ -167,7 +164,7 @@ private class DatabaseUpdateCommandTest {
     Contact c = [SELECT Id FROM Contact LIMIT 1];
 
     List<Id> oppIds = new List<Id>();
-    List<DonationAcknowledgementService.OpportunityResult> successfulOpps = new List<DonationAcknowledgementService.OpportunityResult>();
+    List<AckOpportunityResult> successfulOpps = new List<AckOpportunityResult>();
 
     Date today = Date.today();
     Date yesterday = today.addDays(-1);
@@ -181,7 +178,7 @@ private class DatabaseUpdateCommandTest {
     );
     oppIds.add(opp1.Id);
 
-    DonationAcknowledgementService.OpportunityResult result1 = new DonationAcknowledgementService.OpportunityResult(
+    AckOpportunityResult result1 = new AckOpportunityResult(
       opp1.Id,
       'Today Opp'
     );
@@ -196,7 +193,7 @@ private class DatabaseUpdateCommandTest {
     );
     oppIds.add(opp2.Id);
 
-    DonationAcknowledgementService.OpportunityResult result2 = new DonationAcknowledgementService.OpportunityResult(
+    AckOpportunityResult result2 = new AckOpportunityResult(
       opp2.Id,
       'Yesterday Opp'
     );
@@ -249,13 +246,13 @@ private class DatabaseUpdateCommandTest {
     // Note: In test context, DML operations are more forgiving
     // This test verifies the command structure handles errors properly
 
-    DonationAcknowledgementService.OpportunityResult invalidResult = new DonationAcknowledgementService.OpportunityResult(
+    AckOpportunityResult invalidResult = new AckOpportunityResult(
       '006000000000000AAA', // Invalid ID format
       'Invalid Opportunity'
     );
     invalidResult.acknowledgmentDate = Date.today();
 
-    List<DonationAcknowledgementService.OpportunityResult> invalidOpps = new List<DonationAcknowledgementService.OpportunityResult>{
+    List<AckOpportunityResult> invalidOpps = new List<AckOpportunityResult>{
       invalidResult
     };
 
@@ -286,20 +283,17 @@ private class DatabaseUpdateCommandTest {
     // Test that opportunity results are properly modified on database errors
     Opportunity opp = [SELECT Id, Name FROM Opportunity LIMIT 1];
 
-    DonationAcknowledgementService.OpportunityResult oppResult = new DonationAcknowledgementService.OpportunityResult(
-      opp.Id,
-      opp.Name
-    );
+    AckOpportunityResult oppResult = new AckOpportunityResult(opp.Id, opp.Name);
     oppResult.acknowledgmentDate = Date.today();
 
     // Verify initial state
     System.assertNotEquals(
-      DonationAcknowledgementService.AckStatus.EMAIL_SEND_FAILED,
+      AckStatus.EMAIL_SEND_FAILED,
       oppResult.status,
       'Status should not start as failed'
     );
 
-    List<DonationAcknowledgementService.OpportunityResult> successfulOpps = new List<DonationAcknowledgementService.OpportunityResult>{
+    List<AckOpportunityResult> successfulOpps = new List<AckOpportunityResult>{
       oppResult
     };
 
@@ -319,7 +313,7 @@ private class DatabaseUpdateCommandTest {
     } catch (AuraHandledException e) {
       // In error case, verify opportunity results were marked as failed
       System.assertEquals(
-        DonationAcknowledgementService.AckStatus.EMAIL_SEND_FAILED,
+        AckStatus.EMAIL_SEND_FAILED,
         oppResult.status,
         'Status should be marked as failed on database error'
       );
@@ -336,13 +330,10 @@ private class DatabaseUpdateCommandTest {
     // Test the structure and properties of the UpdateOutput class
     Opportunity opp = [SELECT Id, Name FROM Opportunity LIMIT 1];
 
-    DonationAcknowledgementService.OpportunityResult oppResult = new DonationAcknowledgementService.OpportunityResult(
-      opp.Id,
-      opp.Name
-    );
+    AckOpportunityResult oppResult = new AckOpportunityResult(opp.Id, opp.Name);
     oppResult.acknowledgmentDate = Date.today();
 
-    List<DonationAcknowledgementService.OpportunityResult> successfulOpps = new List<DonationAcknowledgementService.OpportunityResult>{
+    List<AckOpportunityResult> successfulOpps = new List<AckOpportunityResult>{
       oppResult
     };
 
@@ -382,13 +373,10 @@ private class DatabaseUpdateCommandTest {
 
     Opportunity opp = [SELECT Id, Name FROM Opportunity LIMIT 1];
 
-    DonationAcknowledgementService.OpportunityResult oppResult = new DonationAcknowledgementService.OpportunityResult(
-      opp.Id,
-      opp.Name
-    );
+    AckOpportunityResult oppResult = new AckOpportunityResult(opp.Id, opp.Name);
     // Deliberately leave acknowledgmentDate as null
 
-    List<DonationAcknowledgementService.OpportunityResult> successfulOpps = new List<DonationAcknowledgementService.OpportunityResult>{
+    List<AckOpportunityResult> successfulOpps = new List<AckOpportunityResult>{
       oppResult
     };
 
@@ -429,13 +417,10 @@ private class DatabaseUpdateCommandTest {
     Opportunity opp = [SELECT Id, Name FROM Opportunity LIMIT 1];
 
     // Create successful opportunity result
-    DonationAcknowledgementService.OpportunityResult oppResult = new DonationAcknowledgementService.OpportunityResult(
-      opp.Id,
-      opp.Name
-    );
+    AckOpportunityResult oppResult = new AckOpportunityResult(opp.Id, opp.Name);
     oppResult.acknowledgmentDate = Date.today();
 
-    List<DonationAcknowledgementService.OpportunityResult> successfulOpps = new List<DonationAcknowledgementService.OpportunityResult>{
+    List<AckOpportunityResult> successfulOpps = new List<AckOpportunityResult>{
       oppResult
     };
 

--- a/force-app/main/default/classes/tests/commands/EmailPreparationCommandTest.cls
+++ b/force-app/main/default/classes/tests/commands/EmailPreparationCommandTest.cls
@@ -38,7 +38,7 @@ private class EmailPreparationCommandTest {
       new List<Id>{ validOpp.Id }
     );
 
-    DonationAcknowledgementService.EmailConfig config = new DonationAcknowledgementService.EmailConfig(
+    AckEmailConfig config = new AckEmailConfig(
       'Test Subject',
       'Test Body Content'
     );
@@ -88,7 +88,7 @@ private class EmailPreparationCommandTest {
     );
 
     // Verify opportunity result properties
-    DonationAcknowledgementService.OpportunityResult oppResult = output.validOpportunities[0];
+    AckOpportunityResult oppResult = output.validOpportunities[0];
     System.assertEquals(
       validOpp.Id,
       oppResult.opportunityId,
@@ -137,10 +137,7 @@ private class EmailPreparationCommandTest {
       oppIds
     );
 
-    DonationAcknowledgementService.EmailConfig config = new DonationAcknowledgementService.EmailConfig(
-      'Multi Subject',
-      'Multi Body'
-    );
+    AckEmailConfig config = new AckEmailConfig('Multi Subject', 'Multi Body');
 
     Test.startTest();
     EmailPreparationCommand prepCmd = new EmailPreparationCommand(
@@ -189,9 +186,7 @@ private class EmailPreparationCommandTest {
 
     // Verify all opportunity results have correct data
     Set<Id> processedOppIds = new Set<Id>();
-    for (
-      DonationAcknowledgementService.OpportunityResult oppResult : output.validOpportunities
-    ) {
+    for (AckOpportunityResult oppResult : output.validOpportunities) {
       processedOppIds.add(oppResult.opportunityId);
       System.assertEquals(
         'testuser@example.com',
@@ -217,10 +212,7 @@ private class EmailPreparationCommandTest {
   static void testPrepareEmailsEmptyList() {
     // Test email preparation with empty opportunity list
     List<Opportunity> emptyOpps = new List<Opportunity>();
-    DonationAcknowledgementService.EmailConfig config = new DonationAcknowledgementService.EmailConfig(
-      'Empty Subject',
-      'Empty Body'
-    );
+    AckEmailConfig config = new AckEmailConfig('Empty Subject', 'Empty Body');
 
     Test.startTest();
     EmailPreparationCommand prepCmd = new EmailPreparationCommand(
@@ -257,10 +249,7 @@ private class EmailPreparationCommandTest {
 
     List<Opportunity> emptyContactOpps = new List<Opportunity>();
 
-    DonationAcknowledgementService.EmailConfig config = new DonationAcknowledgementService.EmailConfig(
-      'Test Subject',
-      'Test Body'
-    );
+    AckEmailConfig config = new AckEmailConfig('Test Subject', 'Test Body');
 
     Test.startTest();
     EmailPreparationCommand prepCmd = new EmailPreparationCommand(
@@ -304,7 +293,7 @@ private class EmailPreparationCommandTest {
       new List<Id>{ validOpp.Id }
     );
 
-    DonationAcknowledgementService.EmailConfig config = new DonationAcknowledgementService.EmailConfig(
+    AckEmailConfig config = new AckEmailConfig(
       'Detailed Subject',
       'Detailed Body Content'
     );
@@ -358,7 +347,7 @@ private class EmailPreparationCommandTest {
     );
 
     // Verify opportunity result details
-    DonationAcknowledgementService.OpportunityResult oppResult = output.validOpportunities[0];
+    AckOpportunityResult oppResult = output.validOpportunities[0];
     System.assertEquals(
       validOpp.Id,
       oppResult.opportunityId,

--- a/force-app/main/default/classes/tests/commands/EmailSendCommandTest.cls
+++ b/force-app/main/default/classes/tests/commands/EmailSendCommandTest.cls
@@ -31,7 +31,7 @@ private class EmailSendCommandTest {
     email.setTargetObjectId(c.Id);
 
     // Create opportunity result
-    DonationAcknowledgementService.OpportunityResult oppResult = new DonationAcknowledgementService.OpportunityResult(
+    AckOpportunityResult oppResult = new AckOpportunityResult(
       '006000000000001AAA',
       'Test Opportunity'
     );
@@ -40,7 +40,7 @@ private class EmailSendCommandTest {
     List<Messaging.SingleEmailMessage> emails = new List<Messaging.SingleEmailMessage>{
       email
     };
-    List<DonationAcknowledgementService.OpportunityResult> oppResults = new List<DonationAcknowledgementService.OpportunityResult>{
+    List<AckOpportunityResult> oppResults = new List<AckOpportunityResult>{
       oppResult
     };
 
@@ -70,9 +70,9 @@ private class EmailSendCommandTest {
     );
 
     // Verify opportunity result was marked as successful
-    DonationAcknowledgementService.OpportunityResult result = output.successfulOpportunities[0];
+    AckOpportunityResult result = output.successfulOpportunities[0];
     System.assertEquals(
-      DonationAcknowledgementService.AckStatus.SUCCESS,
+      AckStatus.SUCCESS,
       result.status,
       'Should be marked as successful'
     );
@@ -99,7 +99,7 @@ private class EmailSendCommandTest {
     Contact c = [SELECT Id FROM Contact LIMIT 1];
 
     List<Messaging.SingleEmailMessage> emails = new List<Messaging.SingleEmailMessage>();
-    List<DonationAcknowledgementService.OpportunityResult> oppResults = new List<DonationAcknowledgementService.OpportunityResult>();
+    List<AckOpportunityResult> oppResults = new List<AckOpportunityResult>();
 
     // Create multiple prepared emails and opportunity results
     for (Integer i = 1; i <= 3; i++) {
@@ -109,7 +109,7 @@ private class EmailSendCommandTest {
       email.setTargetObjectId(c.Id);
       emails.add(email);
 
-      DonationAcknowledgementService.OpportunityResult oppResult = new DonationAcknowledgementService.OpportunityResult(
+      AckOpportunityResult oppResult = new AckOpportunityResult(
         '00600000000000' + i + 'AAA',
         'Test Opportunity ' + i
       );
@@ -143,11 +143,9 @@ private class EmailSendCommandTest {
     );
 
     // Verify all opportunity results were marked as successful
-    for (
-      DonationAcknowledgementService.OpportunityResult result : output.successfulOpportunities
-    ) {
+    for (AckOpportunityResult result : output.successfulOpportunities) {
       System.assertEquals(
-        DonationAcknowledgementService.AckStatus.SUCCESS,
+        AckStatus.SUCCESS,
         result.status,
         'Should be marked as successful'
       );
@@ -173,7 +171,7 @@ private class EmailSendCommandTest {
     MockEmailService mock = new MockEmailService();
     mock.setSuccessful();
     List<Messaging.SingleEmailMessage> emptyEmails = new List<Messaging.SingleEmailMessage>();
-    List<DonationAcknowledgementService.OpportunityResult> emptyResults = new List<DonationAcknowledgementService.OpportunityResult>();
+    List<AckOpportunityResult> emptyResults = new List<AckOpportunityResult>();
 
     Test.startTest();
     EmailSendCommand sendCmd = new EmailSendCommand(emptyEmails, emptyResults);
@@ -222,7 +220,7 @@ private class EmailSendCommandTest {
     email.setTargetObjectId(c.Id);
 
     // Create opportunity result
-    DonationAcknowledgementService.OpportunityResult oppResult = new DonationAcknowledgementService.OpportunityResult(
+    AckOpportunityResult oppResult = new AckOpportunityResult(
       '006000000000002AAA',
       'Error Test Opportunity'
     );
@@ -231,7 +229,7 @@ private class EmailSendCommandTest {
     List<Messaging.SingleEmailMessage> emails = new List<Messaging.SingleEmailMessage>{
       email
     };
-    List<DonationAcknowledgementService.OpportunityResult> oppResults = new List<DonationAcknowledgementService.OpportunityResult>{
+    List<AckOpportunityResult> oppResults = new List<AckOpportunityResult>{
       oppResult
     };
 
@@ -275,7 +273,7 @@ private class EmailSendCommandTest {
     email.setPlainTextBody('Status Test Body');
     email.setTargetObjectId(c.Id);
 
-    DonationAcknowledgementService.OpportunityResult oppResult = new DonationAcknowledgementService.OpportunityResult(
+    AckOpportunityResult oppResult = new AckOpportunityResult(
       '006000000000003AAA',
       'Status Test Opportunity'
     );
@@ -293,7 +291,7 @@ private class EmailSendCommandTest {
     List<Messaging.SingleEmailMessage> emails = new List<Messaging.SingleEmailMessage>{
       email
     };
-    List<DonationAcknowledgementService.OpportunityResult> oppResults = new List<DonationAcknowledgementService.OpportunityResult>{
+    List<AckOpportunityResult> oppResults = new List<AckOpportunityResult>{
       oppResult
     };
 
@@ -305,7 +303,7 @@ private class EmailSendCommandTest {
     Test.stopTest();
 
     // Verify opportunity result was updated
-    DonationAcknowledgementService.OpportunityResult updatedResult = output.successfulOpportunities[0];
+    AckOpportunityResult updatedResult = output.successfulOpportunities[0];
 
     // Check that it's the same object reference (should be modified in place)
     System.assertEquals(
@@ -316,7 +314,7 @@ private class EmailSendCommandTest {
 
     // Verify status updates
     System.assertEquals(
-      DonationAcknowledgementService.AckStatus.SUCCESS,
+      AckStatus.SUCCESS,
       oppResult.status,
       'Original object should be updated with success status'
     );
@@ -347,7 +345,7 @@ private class EmailSendCommandTest {
     email.setPlainTextBody('Output Test Body');
     email.setTargetObjectId(c.Id);
 
-    DonationAcknowledgementService.OpportunityResult oppResult = new DonationAcknowledgementService.OpportunityResult(
+    AckOpportunityResult oppResult = new AckOpportunityResult(
       '006000000000006AAA',
       'Output Test Opportunity'
     );
@@ -356,7 +354,7 @@ private class EmailSendCommandTest {
     List<Messaging.SingleEmailMessage> emails = new List<Messaging.SingleEmailMessage>{
       email
     };
-    List<DonationAcknowledgementService.OpportunityResult> oppResults = new List<DonationAcknowledgementService.OpportunityResult>{
+    List<AckOpportunityResult> oppResults = new List<AckOpportunityResult>{
       oppResult
     };
 
@@ -399,7 +397,7 @@ private class EmailSendCommandTest {
     );
 
     // Verify successful opportunity details
-    DonationAcknowledgementService.OpportunityResult successResult = output.successfulOpportunities[0];
+    AckOpportunityResult successResult = output.successfulOpportunities[0];
     System.assertEquals(
       '006000000000006AAA',
       successResult.opportunityId,

--- a/force-app/main/default/classes/tests/commands/OpportunityValidationCommandTest.cls
+++ b/force-app/main/default/classes/tests/commands/OpportunityValidationCommandTest.cls
@@ -38,7 +38,7 @@ private class OpportunityValidationCommandTest {
       new List<Id>{ validOpp.Id }
     );
 
-    DonationAcknowledgementService.DetailedAckResult result = new DonationAcknowledgementService.DetailedAckResult();
+    AckDetailedResult result = new AckDetailedResult();
 
     Test.startTest();
     OpportunityValidationCommand validationCmd = new OpportunityValidationCommand(
@@ -80,7 +80,7 @@ private class OpportunityValidationCommandTest {
       new List<Id>{ acknowledgedOpp.Id }
     );
 
-    DonationAcknowledgementService.DetailedAckResult result = new DonationAcknowledgementService.DetailedAckResult();
+    AckDetailedResult result = new AckDetailedResult();
 
     Test.startTest();
     OpportunityValidationCommand validationCmd = new OpportunityValidationCommand(
@@ -104,9 +104,9 @@ private class OpportunityValidationCommandTest {
       result.opportunityResults.size(),
       'Should have 1 skipped result'
     );
-    DonationAcknowledgementService.OpportunityResult oppResult = result.opportunityResults[0];
+    AckOpportunityResult oppResult = result.opportunityResults[0];
     System.assertEquals(
-      DonationAcknowledgementService.AckStatus.ALREADY_ACKNOWLEDGED,
+      AckStatus.ALREADY_ACKNOWLEDGED,
       oppResult.status,
       'Should be already acknowledged'
     );
@@ -130,7 +130,7 @@ private class OpportunityValidationCommandTest {
       new List<Id>{ noContactOpp.Id }
     );
 
-    DonationAcknowledgementService.DetailedAckResult result = new DonationAcknowledgementService.DetailedAckResult();
+    AckDetailedResult result = new AckDetailedResult();
 
     Test.startTest();
     OpportunityValidationCommand validationCmd = new OpportunityValidationCommand(
@@ -154,9 +154,9 @@ private class OpportunityValidationCommandTest {
       result.opportunityResults.size(),
       'Should have 1 skipped result'
     );
-    DonationAcknowledgementService.OpportunityResult oppResult = result.opportunityResults[0];
+    AckOpportunityResult oppResult = result.opportunityResults[0];
     System.assertEquals(
-      DonationAcknowledgementService.AckStatus.NO_CONTACT,
+      AckStatus.NO_CONTACT,
       oppResult.status,
       'Should be no contact'
     );
@@ -181,7 +181,7 @@ private class OpportunityValidationCommandTest {
       new List<Id>{ noEmailOpp.Id }
     );
 
-    DonationAcknowledgementService.DetailedAckResult result = new DonationAcknowledgementService.DetailedAckResult();
+    AckDetailedResult result = new AckDetailedResult();
 
     Test.startTest();
     OpportunityValidationCommand validationCmd = new OpportunityValidationCommand(
@@ -205,9 +205,9 @@ private class OpportunityValidationCommandTest {
       result.opportunityResults.size(),
       'Should have 1 skipped result'
     );
-    DonationAcknowledgementService.OpportunityResult oppResult = result.opportunityResults[0];
+    AckOpportunityResult oppResult = result.opportunityResults[0];
     System.assertEquals(
-      DonationAcknowledgementService.AckStatus.NO_EMAIL,
+      AckStatus.NO_EMAIL,
       oppResult.status,
       'Should be no email'
     );
@@ -221,7 +221,7 @@ private class OpportunityValidationCommandTest {
   static void testValidateOpportunitiesEmptyList() {
     // Test validation with empty opportunity list
     List<Opportunity> emptyOpps = new List<Opportunity>();
-    DonationAcknowledgementService.DetailedAckResult result = new DonationAcknowledgementService.DetailedAckResult();
+    AckDetailedResult result = new AckDetailedResult();
 
     Test.startTest();
     OpportunityValidationCommand validationCmd = new OpportunityValidationCommand(
@@ -260,7 +260,7 @@ private class OpportunityValidationCommandTest {
       new List<Id>{ acknowledgedOpp.Id }
     );
 
-    DonationAcknowledgementService.DetailedAckResult result = new DonationAcknowledgementService.DetailedAckResult();
+    AckDetailedResult result = new AckDetailedResult();
 
     Test.startTest();
     OpportunityValidationCommand validationCmd = new OpportunityValidationCommand(
@@ -284,9 +284,9 @@ private class OpportunityValidationCommandTest {
       result.opportunityResults.size(),
       'Should have 1 opportunity result'
     );
-    DonationAcknowledgementService.OpportunityResult oppResult = result.opportunityResults[0];
+    AckOpportunityResult oppResult = result.opportunityResults[0];
     System.assertEquals(
-      DonationAcknowledgementService.AckStatus.ALREADY_ACKNOWLEDGED,
+      AckStatus.ALREADY_ACKNOWLEDGED,
       oppResult.status,
       'Status should be ALREADY_ACKNOWLEDGED'
     );

--- a/force-app/main/default/classes/tests/commands/ResultAggregationCommandTest.cls
+++ b/force-app/main/default/classes/tests/commands/ResultAggregationCommandTest.cls
@@ -22,7 +22,7 @@ private class ResultAggregationCommandTest {
     // Test result aggregation with successful email sending scenario
 
     // Create initial DetailedAckResult
-    DonationAcknowledgementService.DetailedAckResult result = new DonationAcknowledgementService.DetailedAckResult();
+    AckDetailedResult result = new AckDetailedResult();
 
     // Create email preparation output
     AcknowledgementCommandOutputs.EmailPrepOutput prepOutput = new AcknowledgementCommandOutputs.EmailPrepOutput();
@@ -34,7 +34,7 @@ private class ResultAggregationCommandTest {
     );
     prepOutput.contactMap.put(testContact.Id, testContact);
 
-    DonationAcknowledgementService.OpportunityResult prepResult = new DonationAcknowledgementService.OpportunityResult(
+    AckOpportunityResult prepResult = new AckOpportunityResult(
       '006000000000001AAA',
       'Success Opportunity'
     );
@@ -44,21 +44,14 @@ private class ResultAggregationCommandTest {
     // Create successful send output
     AcknowledgementCommandOutputs.SendOutput sendOutput = new AcknowledgementCommandOutputs.SendOutput();
 
-    DonationAcknowledgementService.OpportunityResult successResult = new DonationAcknowledgementService.OpportunityResult(
+    AckOpportunityResult successResult = new AckOpportunityResult(
       '006000000000001AAA',
       'Success Opportunity'
     );
-    successResult.setStatus(
-      DonationAcknowledgementService.AckStatus.SUCCESS,
-      'Email sent successfully'
-    );
+    successResult.setStatus(AckStatus.SUCCESS, 'Email sent successfully');
     successResult.acknowledgmentDate = Date.today();
 
-    sendOutput.setSuccess(
-      new List<DonationAcknowledgementService.OpportunityResult>{
-        successResult
-      }
-    );
+    sendOutput.setSuccess(new List<AckOpportunityResult>{ successResult });
 
     // Create successful update output
     AcknowledgementCommandOutputs.UpdateOutput updateOutput = new AcknowledgementCommandOutputs.UpdateOutput();
@@ -90,7 +83,7 @@ private class ResultAggregationCommandTest {
     );
 
     // Verify opportunity result details
-    DonationAcknowledgementService.OpportunityResult finalResult = result.opportunityResults[0];
+    AckOpportunityResult finalResult = result.opportunityResults[0];
     System.assertEquals(
       '006000000000001AAA',
       finalResult.opportunityId,
@@ -102,7 +95,7 @@ private class ResultAggregationCommandTest {
       'Should have correct opportunity name'
     );
     System.assertEquals(
-      DonationAcknowledgementService.AckStatus.SUCCESS,
+      AckStatus.SUCCESS,
       finalResult.status,
       'Should have success status'
     );
@@ -123,7 +116,7 @@ private class ResultAggregationCommandTest {
     // Test result aggregation with failed email sending scenario
 
     // Create initial DetailedAckResult
-    DonationAcknowledgementService.DetailedAckResult result = new DonationAcknowledgementService.DetailedAckResult();
+    AckDetailedResult result = new AckDetailedResult();
 
     // Create email preparation output
     AcknowledgementCommandOutputs.EmailPrepOutput prepOutput = new AcknowledgementCommandOutputs.EmailPrepOutput();
@@ -131,18 +124,15 @@ private class ResultAggregationCommandTest {
     // Create failed send output
     AcknowledgementCommandOutputs.SendOutput sendOutput = new AcknowledgementCommandOutputs.SendOutput();
 
-    DonationAcknowledgementService.OpportunityResult failedResult = new DonationAcknowledgementService.OpportunityResult(
+    AckOpportunityResult failedResult = new AckOpportunityResult(
       '006000000000002AAA',
       'Failed Opportunity'
     );
-    failedResult.setStatus(
-      DonationAcknowledgementService.AckStatus.EMAIL_SEND_FAILED,
-      'Email sending failed'
-    );
+    failedResult.setStatus(AckStatus.EMAIL_SEND_FAILED, 'Email sending failed');
 
     sendOutput.setFailure(
       'Failed to send emails',
-      new List<DonationAcknowledgementService.OpportunityResult>{ failedResult }
+      new List<AckOpportunityResult>{ failedResult }
     );
 
     // Create update output (not used in failed scenario)
@@ -174,7 +164,7 @@ private class ResultAggregationCommandTest {
     );
 
     // Verify failed opportunity result details
-    DonationAcknowledgementService.OpportunityResult finalResult = result.opportunityResults[0];
+    AckOpportunityResult finalResult = result.opportunityResults[0];
     System.assertEquals(
       '006000000000002AAA',
       finalResult.opportunityId,
@@ -186,7 +176,7 @@ private class ResultAggregationCommandTest {
       'Should have correct opportunity name'
     );
     System.assertEquals(
-      DonationAcknowledgementService.AckStatus.EMAIL_SEND_FAILED,
+      AckStatus.EMAIL_SEND_FAILED,
       finalResult.status,
       'Should have failed status'
     );
@@ -202,7 +192,7 @@ private class ResultAggregationCommandTest {
     // Test result aggregation with multiple opportunities (mixed success/failure)
 
     // Create initial DetailedAckResult
-    DonationAcknowledgementService.DetailedAckResult result = new DonationAcknowledgementService.DetailedAckResult();
+    AckDetailedResult result = new AckDetailedResult();
 
     // Create email preparation output
     AcknowledgementCommandOutputs.EmailPrepOutput prepOutput = new AcknowledgementCommandOutputs.EmailPrepOutput();
@@ -211,17 +201,14 @@ private class ResultAggregationCommandTest {
     AcknowledgementCommandOutputs.SendOutput sendOutput = new AcknowledgementCommandOutputs.SendOutput();
 
     // Create successful opportunity results
-    List<DonationAcknowledgementService.OpportunityResult> successfulResults = new List<DonationAcknowledgementService.OpportunityResult>();
+    List<AckOpportunityResult> successfulResults = new List<AckOpportunityResult>();
 
     for (Integer i = 1; i <= 2; i++) {
-      DonationAcknowledgementService.OpportunityResult successResult = new DonationAcknowledgementService.OpportunityResult(
+      AckOpportunityResult successResult = new AckOpportunityResult(
         '00600000000000' + i + 'AAA',
         'Success Opportunity ' + i
       );
-      successResult.setStatus(
-        DonationAcknowledgementService.AckStatus.SUCCESS,
-        'Email sent successfully'
-      );
+      successResult.setStatus(AckStatus.SUCCESS, 'Email sent successfully');
       successResult.acknowledgmentDate = Date.today();
       successfulResults.add(successResult);
     }
@@ -258,11 +245,9 @@ private class ResultAggregationCommandTest {
     );
 
     // Verify all opportunity results
-    for (
-      DonationAcknowledgementService.OpportunityResult finalResult : result.opportunityResults
-    ) {
+    for (AckOpportunityResult finalResult : result.opportunityResults) {
       System.assertEquals(
-        DonationAcknowledgementService.AckStatus.SUCCESS,
+        AckStatus.SUCCESS,
         finalResult.status,
         'Should have success status'
       );
@@ -288,27 +273,24 @@ private class ResultAggregationCommandTest {
     // Test result aggregation when DetailedAckResult already contains skipped opportunities
 
     // Create initial DetailedAckResult with existing skipped opportunities
-    DonationAcknowledgementService.DetailedAckResult result = new DonationAcknowledgementService.DetailedAckResult();
+    AckDetailedResult result = new AckDetailedResult();
 
     // Add some pre-existing skipped opportunities (from validation command)
-    DonationAcknowledgementService.OpportunityResult skippedResult1 = new DonationAcknowledgementService.OpportunityResult(
+    AckOpportunityResult skippedResult1 = new AckOpportunityResult(
       '006000000000003AAA',
       'Already Acknowledged Opp'
     );
     skippedResult1.setStatus(
-      DonationAcknowledgementService.AckStatus.ALREADY_ACKNOWLEDGED,
+      AckStatus.ALREADY_ACKNOWLEDGED,
       'Already acknowledged'
     );
     result.addOpportunityResult(skippedResult1);
 
-    DonationAcknowledgementService.OpportunityResult skippedResult2 = new DonationAcknowledgementService.OpportunityResult(
+    AckOpportunityResult skippedResult2 = new AckOpportunityResult(
       '006000000000004AAA',
       'No Contact Opp'
     );
-    skippedResult2.setStatus(
-      DonationAcknowledgementService.AckStatus.NO_CONTACT,
-      'No contact'
-    );
+    skippedResult2.setStatus(AckStatus.NO_CONTACT, 'No contact');
     result.addOpportunityResult(skippedResult2);
 
     // Create email preparation output
@@ -317,21 +299,14 @@ private class ResultAggregationCommandTest {
     // Create successful send output
     AcknowledgementCommandOutputs.SendOutput sendOutput = new AcknowledgementCommandOutputs.SendOutput();
 
-    DonationAcknowledgementService.OpportunityResult successResult = new DonationAcknowledgementService.OpportunityResult(
+    AckOpportunityResult successResult = new AckOpportunityResult(
       '006000000000005AAA',
       'New Success Opportunity'
     );
-    successResult.setStatus(
-      DonationAcknowledgementService.AckStatus.SUCCESS,
-      'Email sent successfully'
-    );
+    successResult.setStatus(AckStatus.SUCCESS, 'Email sent successfully');
     successResult.acknowledgmentDate = Date.today();
 
-    sendOutput.setSuccess(
-      new List<DonationAcknowledgementService.OpportunityResult>{
-        successResult
-      }
-    );
+    sendOutput.setSuccess(new List<AckOpportunityResult>{ successResult });
 
     // Create update output
     AcknowledgementCommandOutputs.UpdateOutput updateOutput = new AcknowledgementCommandOutputs.UpdateOutput();
@@ -363,7 +338,7 @@ private class ResultAggregationCommandTest {
     );
 
     // Verify result contains all expected opportunities
-    Map<String, DonationAcknowledgementService.OpportunityResult> resultsByName = AcknowledgementTestUtils.createResultsByNameMap(
+    Map<String, AckOpportunityResult> resultsByName = AcknowledgementTestUtils.createResultsByNameMap(
       result.opportunityResults
     );
 
@@ -371,14 +346,14 @@ private class ResultAggregationCommandTest {
     AcknowledgementTestUtils.assertOpportunityResult(
       resultsByName,
       'Already Acknowledged Opp',
-      DonationAcknowledgementService.AckStatus.ALREADY_ACKNOWLEDGED,
+      AckStatus.ALREADY_ACKNOWLEDGED,
       'Already acknowledged'
     );
 
     AcknowledgementTestUtils.assertOpportunityResult(
       resultsByName,
       'No Contact Opp',
-      DonationAcknowledgementService.AckStatus.NO_CONTACT,
+      AckStatus.NO_CONTACT,
       'No contact'
     );
 
@@ -386,7 +361,7 @@ private class ResultAggregationCommandTest {
     AcknowledgementTestUtils.assertOpportunityResult(
       resultsByName,
       'New Success Opportunity',
-      DonationAcknowledgementService.AckStatus.SUCCESS,
+      AckStatus.SUCCESS,
       'Email sent successfully'
     );
   }
@@ -396,15 +371,13 @@ private class ResultAggregationCommandTest {
     // Test result aggregation with empty inputs
 
     // Create initial DetailedAckResult
-    DonationAcknowledgementService.DetailedAckResult result = new DonationAcknowledgementService.DetailedAckResult();
+    AckDetailedResult result = new AckDetailedResult();
 
     // Create empty outputs
     AcknowledgementCommandOutputs.EmailPrepOutput prepOutput = new AcknowledgementCommandOutputs.EmailPrepOutput();
 
     AcknowledgementCommandOutputs.SendOutput sendOutput = new AcknowledgementCommandOutputs.SendOutput();
-    sendOutput.setSuccess(
-      new List<DonationAcknowledgementService.OpportunityResult>()
-    );
+    sendOutput.setSuccess(new List<AckOpportunityResult>());
 
     AcknowledgementCommandOutputs.UpdateOutput updateOutput = new AcknowledgementCommandOutputs.UpdateOutput();
     updateOutput.setSuccess(0);
@@ -440,15 +413,13 @@ private class ResultAggregationCommandTest {
     // Test that email type metadata is properly set
 
     // Create initial DetailedAckResult
-    DonationAcknowledgementService.DetailedAckResult result = new DonationAcknowledgementService.DetailedAckResult();
+    AckDetailedResult result = new AckDetailedResult();
 
     // Create minimal outputs
     AcknowledgementCommandOutputs.EmailPrepOutput prepOutput = new AcknowledgementCommandOutputs.EmailPrepOutput();
 
     AcknowledgementCommandOutputs.SendOutput sendOutput = new AcknowledgementCommandOutputs.SendOutput();
-    sendOutput.setSuccess(
-      new List<DonationAcknowledgementService.OpportunityResult>()
-    );
+    sendOutput.setSuccess(new List<AckOpportunityResult>());
 
     AcknowledgementCommandOutputs.UpdateOutput updateOutput = new AcknowledgementCommandOutputs.UpdateOutput();
     updateOutput.setSuccess(0);
@@ -475,7 +446,7 @@ private class ResultAggregationCommandTest {
     );
 
     // Test null email type case without Test.startTest()
-    result = new DonationAcknowledgementService.DetailedAckResult();
+    result = new AckDetailedResult();
     ResultAggregationCommand nullCmd = new ResultAggregationCommand(
       result,
       prepOutput,
@@ -497,7 +468,7 @@ private class ResultAggregationCommandTest {
     // and doesn't return a value (implements command pattern correctly)
 
     // Create initial DetailedAckResult
-    DonationAcknowledgementService.DetailedAckResult result = new DonationAcknowledgementService.DetailedAckResult();
+    AckDetailedResult result = new AckDetailedResult();
 
     // Verify initial state
     System.assertEquals(
@@ -516,18 +487,13 @@ private class ResultAggregationCommandTest {
 
     AcknowledgementCommandOutputs.SendOutput sendOutput = new AcknowledgementCommandOutputs.SendOutput();
 
-    DonationAcknowledgementService.OpportunityResult testResult = new DonationAcknowledgementService.OpportunityResult(
+    AckOpportunityResult testResult = new AckOpportunityResult(
       '006000000000008AAA',
       'Direct Modification Test'
     );
-    testResult.setStatus(
-      DonationAcknowledgementService.AckStatus.SUCCESS,
-      'Test reason'
-    );
+    testResult.setStatus(AckStatus.SUCCESS, 'Test reason');
 
-    sendOutput.setSuccess(
-      new List<DonationAcknowledgementService.OpportunityResult>{ testResult }
-    );
+    sendOutput.setSuccess(new List<AckOpportunityResult>{ testResult });
 
     AcknowledgementCommandOutputs.UpdateOutput updateOutput = new AcknowledgementCommandOutputs.UpdateOutput();
     updateOutput.setSuccess(1);
@@ -560,7 +526,7 @@ private class ResultAggregationCommandTest {
     );
 
     // Verify the opportunity result was added
-    DonationAcknowledgementService.OpportunityResult addedResult = result.opportunityResults[0];
+    AckOpportunityResult addedResult = result.opportunityResults[0];
     System.assertEquals(
       '006000000000008AAA',
       addedResult.opportunityId,
@@ -572,7 +538,7 @@ private class ResultAggregationCommandTest {
       'Should have correct name'
     );
     System.assertEquals(
-      DonationAcknowledgementService.AckStatus.SUCCESS,
+      AckStatus.SUCCESS,
       addedResult.status,
       'Should have correct status'
     );

--- a/force-app/main/default/classes/tests/services/DonationAcknowledgementServiceImplTest.cls
+++ b/force-app/main/default/classes/tests/services/DonationAcknowledgementServiceImplTest.cls
@@ -30,9 +30,9 @@ private class DonationAcknowledgementServiceImplTest {
     DonationAcknowledgementServiceImpl service = AcknowledgementTestUtils.createConfiguredServiceWithMockEmail();
     Test.startTest();
     try {
-      DonationAcknowledgementService.DetailedAckResult result = service.sendEmailsCoreDetailed(
+      AckDetailedResult result = service.sendEmailsCoreDetailed(
         opps,
-        new DonationAcknowledgementService.EmailConfig(mockTemplateId)
+        new AckEmailConfig(mockTemplateId)
       );
       System.assert(result.emailsSent >= 0, 'Should return a valid count');
     } catch (Exception e) {
@@ -55,12 +55,9 @@ private class DonationAcknowledgementServiceImplTest {
     // Instance-based: create and configure service with mock email
     DonationAcknowledgementServiceImpl service = AcknowledgementTestUtils.createConfiguredServiceWithMockEmail();
     Test.startTest();
-    DonationAcknowledgementService.DetailedAckResult result = service.sendEmailsCoreDetailed(
+    AckDetailedResult result = service.sendEmailsCoreDetailed(
       opps,
-      new DonationAcknowledgementService.EmailConfig(
-        'Test Subject',
-        'Test Body'
-      )
+      new AckEmailConfig('Test Subject', 'Test Body')
     );
     Test.stopTest();
     System.assertEquals(1, result.emailsSent, 'Should process one opportunity');
@@ -96,17 +93,11 @@ private class DonationAcknowledgementServiceImplTest {
     List<Opportunity> opps = AcknowledgementTestUtils.queryOpportunitiesFullFields(
       new List<Id>{ acknowledgedOpp.Id, successOpp.Id, noContactOpp.Id }
     );
-    DonationAcknowledgementService.EmailConfig config = new DonationAcknowledgementService.EmailConfig(
-      'Test Subject',
-      'Test Body'
-    );
+    AckEmailConfig config = new AckEmailConfig('Test Subject', 'Test Body');
     // Instance-based: create and configure service with mock email
     DonationAcknowledgementServiceImpl service = AcknowledgementTestUtils.createConfiguredServiceWithMockEmail();
     Test.startTest();
-    DonationAcknowledgementService.DetailedAckResult result = service.sendEmailsCoreDetailed(
-      opps,
-      config
-    );
+    AckDetailedResult result = service.sendEmailsCoreDetailed(opps, config);
     Test.stopTest();
     AcknowledgementTestUtils.assertDetailedResultCounts(result, 3, 1, 1, 1, 0);
     System.assertEquals(
@@ -139,17 +130,11 @@ private class DonationAcknowledgementServiceImplTest {
     List<Opportunity> opps = AcknowledgementTestUtils.queryOpportunitiesFullFields(
       new List<Id>{ opp1.Id, opp2.Id }
     );
-    DonationAcknowledgementService.EmailConfig config = new DonationAcknowledgementService.EmailConfig(
-      'Test Subject',
-      'Test Body'
-    );
+    AckEmailConfig config = new AckEmailConfig('Test Subject', 'Test Body');
     // Instance-based: create and configure service with mock email
     DonationAcknowledgementServiceImpl service = AcknowledgementTestUtils.createConfiguredServiceWithMockEmail();
     Test.startTest();
-    DonationAcknowledgementService.DetailedAckResult result = service.sendEmailsCoreDetailed(
-      opps,
-      config
-    );
+    AckDetailedResult result = service.sendEmailsCoreDetailed(opps, config);
     Test.stopTest();
     AcknowledgementTestUtils.assertDetailedResultCounts(result, 2, 2, 0, 0, 0);
     System.assertEquals(
@@ -157,11 +142,9 @@ private class DonationAcknowledgementServiceImplTest {
       result.opportunityResults.size(),
       'Should have 2 opportunity results'
     );
-    for (
-      DonationAcknowledgementService.OpportunityResult oppResult : result.opportunityResults
-    ) {
+    for (AckOpportunityResult oppResult : result.opportunityResults) {
       System.assertEquals(
-        DonationAcknowledgementService.AckStatus.SUCCESS,
+        AckStatus.SUCCESS,
         oppResult.status,
         'Should be successful'
       );
@@ -229,20 +212,14 @@ private class DonationAcknowledgementServiceImplTest {
         noEmailOpp.Id
       }
     );
-    DonationAcknowledgementService.EmailConfig config = new DonationAcknowledgementService.EmailConfig(
-      'Test Subject',
-      'Test Body'
-    );
+    AckEmailConfig config = new AckEmailConfig('Test Subject', 'Test Body');
     // Instance-based: create and configure service with mock email
     DonationAcknowledgementServiceImpl service = AcknowledgementTestUtils.createConfiguredServiceWithMockEmail();
     Test.startTest();
-    DonationAcknowledgementService.DetailedAckResult result = service.sendEmailsCoreDetailed(
-      opps,
-      config
-    );
+    AckDetailedResult result = service.sendEmailsCoreDetailed(opps, config);
     Test.stopTest();
     AcknowledgementTestUtils.assertDetailedResultCounts(result, 4, 1, 1, 2, 0);
-    List<DonationAcknowledgementService.OpportunityResult> successfulResults = result.getSuccessfulResults();
+    List<AckOpportunityResult> successfulResults = result.getSuccessfulResults();
     System.assertEquals(
       1,
       successfulResults.size(),
@@ -279,16 +256,10 @@ private class DonationAcknowledgementServiceImplTest {
     List<Opportunity> opps = AcknowledgementTestUtils.queryOpportunitiesFullFields(
       new List<Id>{ validOpp.Id, invalidOpp.Id }
     );
-    DonationAcknowledgementService.EmailConfig config = new DonationAcknowledgementService.EmailConfig(
-      'Test Subject',
-      'Test Body'
-    );
+    AckEmailConfig config = new AckEmailConfig('Test Subject', 'Test Body');
     DonationAcknowledgementServiceImpl service = AcknowledgementTestUtils.createConfiguredServiceWithMockEmail();
     Test.startTest();
-    DonationAcknowledgementService.DetailedAckResult result = service.sendEmailsCoreDetailed(
-      opps,
-      config
-    );
+    AckDetailedResult result = service.sendEmailsCoreDetailed(opps, config);
     Test.stopTest();
     // Add assertions as needed for transaction behavior
   }
@@ -311,16 +282,10 @@ private class DonationAcknowledgementServiceImplTest {
     List<Opportunity> opps = AcknowledgementTestUtils.queryOpportunitiesFullFields(
       oppIds
     );
-    DonationAcknowledgementService.EmailConfig config = new DonationAcknowledgementService.EmailConfig(
-      'Bulk Subject',
-      'Bulk Body'
-    );
+    AckEmailConfig config = new AckEmailConfig('Bulk Subject', 'Bulk Body');
     DonationAcknowledgementServiceImpl service = AcknowledgementTestUtils.createConfiguredServiceWithMockEmail();
     Test.startTest();
-    DonationAcknowledgementService.DetailedAckResult result = service.sendEmailsCoreDetailed(
-      opps,
-      config
-    );
+    AckDetailedResult result = service.sendEmailsCoreDetailed(opps, config);
     Test.stopTest();
     System.assertEquals(
       5,
@@ -340,16 +305,11 @@ private class DonationAcknowledgementServiceImplTest {
       new List<Id>{ opp.Id }
     );
     Id mockTemplateId = '00X000000000000AAA';
-    DonationAcknowledgementService.EmailConfig config = new DonationAcknowledgementService.EmailConfig(
-      mockTemplateId
-    );
+    AckEmailConfig config = new AckEmailConfig(mockTemplateId);
     DonationAcknowledgementServiceImpl service = AcknowledgementTestUtils.createConfiguredServiceWithMockEmail();
     Test.startTest();
     try {
-      DonationAcknowledgementService.DetailedAckResult result = service.sendEmailsCoreDetailed(
-        opps,
-        config
-      );
+      AckDetailedResult result = service.sendEmailsCoreDetailed(opps, config);
       System.assert(result.emailsSent >= 0, 'Should return a valid count');
     } catch (Exception e) {
       System.assert(
@@ -385,23 +345,20 @@ private class DonationAcknowledgementServiceImplTest {
     List<Opportunity> opps = AcknowledgementTestUtils.queryOpportunitiesFullFields(
       new List<Id>{ opp1.Id, opp2.Id }
     );
-    DonationAcknowledgementService.EmailConfig config = new DonationAcknowledgementService.EmailConfig(
+    AckEmailConfig config = new AckEmailConfig(
       'Multi Contact Subject',
       'Multi Contact Body'
     );
     DonationAcknowledgementServiceImpl service = AcknowledgementTestUtils.createConfiguredServiceWithMockEmail();
     Test.startTest();
-    DonationAcknowledgementService.DetailedAckResult result = service.sendEmailsCoreDetailed(
-      opps,
-      config
-    );
+    AckDetailedResult result = service.sendEmailsCoreDetailed(opps, config);
     Test.stopTest();
     System.assertEquals(
       2,
       result.emailsSent,
       'Should send emails to both contacts'
     );
-    Map<String, DonationAcknowledgementService.OpportunityResult> resultsByName = AcknowledgementTestUtils.createResultsByNameMap(
+    Map<String, AckOpportunityResult> resultsByName = AcknowledgementTestUtils.createResultsByNameMap(
       result.opportunityResults
     );
     System.assertEquals(
@@ -430,16 +387,13 @@ private class DonationAcknowledgementServiceImplTest {
     List<Opportunity> opps = AcknowledgementTestUtils.queryOpportunitiesFullFields(
       new List<Id>{ opp.Id }
     );
-    DonationAcknowledgementService.EmailConfig config = new DonationAcknowledgementService.EmailConfig(
+    AckEmailConfig config = new AckEmailConfig(
       'OrgWide Subject',
       'OrgWide Body'
     );
     DonationAcknowledgementServiceImpl service = AcknowledgementTestUtils.createConfiguredServiceWithMockEmail();
     Test.startTest();
-    DonationAcknowledgementService.DetailedAckResult result = service.sendEmailsCoreDetailed(
-      opps,
-      config
-    );
+    AckDetailedResult result = service.sendEmailsCoreDetailed(opps, config);
     Test.stopTest();
     System.assertEquals(
       1,
@@ -475,21 +429,21 @@ private class DonationAcknowledgementServiceImplTest {
     // Case 1: DefaultNoReply
     EmailPreparationCommand cmdDefault = new EmailPreparationCommand(
       new List<Opportunity>(),
-      new DonationAcknowledgementService.EmailConfig('', '')
+      new AckEmailConfig('', '')
     );
     cmdDefault.orgWideEmailService = mockServiceDefault;
     resultDefaultNoReply = cmdDefault.getDefaultOrgWideEmailAddressId();
     // Case 2: UserSelectionAndDefaultNoReply
     EmailPreparationCommand cmdSelection = new EmailPreparationCommand(
       new List<Opportunity>(),
-      new DonationAcknowledgementService.EmailConfig('', '')
+      new AckEmailConfig('', '')
     );
     cmdSelection.orgWideEmailService = mockServiceSelection;
     resultSelection = cmdSelection.getDefaultOrgWideEmailAddressId();
     // Case 3: No default
     EmailPreparationCommand cmdNone = new EmailPreparationCommand(
       new List<Opportunity>(),
-      new DonationAcknowledgementService.EmailConfig('', '')
+      new AckEmailConfig('', '')
     );
     cmdNone.orgWideEmailService = mockServiceNone;
     resultNone = cmdNone.getDefaultOrgWideEmailAddressId();
@@ -520,16 +474,11 @@ private class DonationAcknowledgementServiceImplTest {
       new List<Id>{ opp.Id }
     );
     Id mockTemplateId = '00X000000000000AAA';
-    DonationAcknowledgementService.EmailConfig config = new DonationAcknowledgementService.EmailConfig(
-      mockTemplateId
-    );
+    AckEmailConfig config = new AckEmailConfig(mockTemplateId);
     DonationAcknowledgementServiceImpl service = AcknowledgementTestUtils.createConfiguredServiceWithMockEmail();
     Test.startTest();
     try {
-      DonationAcknowledgementService.DetailedAckResult result = service.sendEmailsCoreDetailed(
-        opps,
-        config
-      );
+      AckDetailedResult result = service.sendEmailsCoreDetailed(opps, config);
       System.assert(result.emailsSent >= 0, 'Should return a valid count');
     } catch (Exception e) {
       System.assert(
@@ -549,16 +498,10 @@ private class DonationAcknowledgementServiceImplTest {
     List<Opportunity> opps = AcknowledgementTestUtils.queryOpportunitiesFullFields(
       new List<Id>{ opp.Id }
     );
-    DonationAcknowledgementService.EmailConfig config = new DonationAcknowledgementService.EmailConfig(
-      'Type Subject',
-      'Type Body'
-    );
+    AckEmailConfig config = new AckEmailConfig('Type Subject', 'Type Body');
     DonationAcknowledgementServiceImpl service = AcknowledgementTestUtils.createConfiguredServiceWithMockEmail();
     Test.startTest();
-    DonationAcknowledgementService.DetailedAckResult result = service.sendEmailsCoreDetailed(
-      opps,
-      config
-    );
+    AckDetailedResult result = service.sendEmailsCoreDetailed(opps, config);
     Test.stopTest();
     System.assert(
       result.emailsSent >= 0,
@@ -606,16 +549,10 @@ private class DonationAcknowledgementServiceImplTest {
         noEmailOpp.Id
       }
     );
-    DonationAcknowledgementService.EmailConfig config = new DonationAcknowledgementService.EmailConfig(
-      'Test Subject',
-      'Test Body'
-    );
+    AckEmailConfig config = new AckEmailConfig('Test Subject', 'Test Body');
     DonationAcknowledgementServiceImpl service = AcknowledgementTestUtils.createConfiguredServiceWithMockEmail();
     Test.startTest();
-    DonationAcknowledgementService.DetailedAckResult result = service.sendEmailsCoreDetailed(
-      opps,
-      config
-    );
+    AckDetailedResult result = service.sendEmailsCoreDetailed(opps, config);
     Test.stopTest();
     AcknowledgementTestUtils.assertDetailedResultCounts(result, 4, 1, 1, 2, 0);
   }
@@ -660,16 +597,13 @@ private class DonationAcknowledgementServiceImplTest {
         noEmailOpp.Id
       }
     );
-    DonationAcknowledgementService.EmailConfig config = new DonationAcknowledgementService.EmailConfig(
+    AckEmailConfig config = new AckEmailConfig(
       'Integration Subject',
       'Integration Body'
     );
     DonationAcknowledgementServiceImpl service = AcknowledgementTestUtils.createConfiguredServiceWithMockEmail();
     Test.startTest();
-    DonationAcknowledgementService.DetailedAckResult result = service.sendEmailsCoreDetailed(
-      opps,
-      config
-    );
+    AckDetailedResult result = service.sendEmailsCoreDetailed(opps, config);
     Test.stopTest();
     String summary = result.buildSummaryMessage();
     System.assert(

--- a/force-app/main/default/classes/tests/utils/AcknowledgementTestUtils.cls
+++ b/force-app/main/default/classes/tests/utils/AcknowledgementTestUtils.cls
@@ -216,7 +216,7 @@ public class AcknowledgementTestUtils {
    * Assert common detailed result counts
    */
   public static void assertDetailedResultCounts(
-    DonationAcknowledgementService.DetailedAckResult result,
+    AckDetailedResult result,
     Integer expectedTotal,
     Integer expectedSent,
     Integer expectedAcknowledged,
@@ -253,11 +253,11 @@ public class AcknowledgementTestUtils {
   /**
    * Create a map of opportunity results by name for easy lookup in tests
    */
-  public static Map<String, DonationAcknowledgementService.OpportunityResult> createResultsByNameMap(
-    List<DonationAcknowledgementService.OpportunityResult> results
+  public static Map<String, AckOpportunityResult> createResultsByNameMap(
+    List<AckOpportunityResult> results
   ) {
-    Map<String, DonationAcknowledgementService.OpportunityResult> resultsByName = new Map<String, DonationAcknowledgementService.OpportunityResult>();
-    for (DonationAcknowledgementService.OpportunityResult result : results) {
+    Map<String, AckOpportunityResult> resultsByName = new Map<String, AckOpportunityResult>();
+    for (AckOpportunityResult result : results) {
       resultsByName.put(result.opportunityName, result);
     }
     return resultsByName;
@@ -267,14 +267,12 @@ public class AcknowledgementTestUtils {
    * Assert opportunity result by name with expected status and partial reason match
    */
   public static void assertOpportunityResult(
-    Map<String, DonationAcknowledgementService.OpportunityResult> resultsByName,
+    Map<String, AckOpportunityResult> resultsByName,
     String oppName,
-    DonationAcknowledgementService.AckStatus expectedStatus,
+    AckStatus expectedStatus,
     String reasonContains
   ) {
-    DonationAcknowledgementService.OpportunityResult result = resultsByName.get(
-      oppName
-    );
+    AckOpportunityResult result = resultsByName.get(oppName);
     System.assertNotEquals(null, result, 'Should have result for ' + oppName);
     System.assertEquals(
       expectedStatus,

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,6 +1,6 @@
-const { jestConfig } = require('@salesforce/sfdx-lwc-jest/config');
+const { jestConfig } = require("@salesforce/sfdx-lwc-jest/config");
 
 module.exports = {
-    ...jestConfig,
-    modulePathIgnorePatterns: ['<rootDir>/.localdevserver']
+  ...jestConfig,
+  modulePathIgnorePatterns: ["<rootDir>/.localdevserver"]
 };

--- a/manifest/package.xml
+++ b/manifest/package.xml
@@ -1,8 +1,12 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <Package xmlns="http://soap.sforce.com/2006/04/metadata">
     <types>
+        <members>AckDetailedResult</members>
+        <members>AckEmailConfig</members>
         <members>AcknowledgementCommandOutputs</members>
         <members>AcknowledgementTestUtils</members>
+        <members>AckOpportunityResult</members>
+        <members>AckStatus</members>
         <members>DatabaseUpdateCommand</members>
         <members>DatabaseUpdateCommandTest</members>
         <members>DonationAcknowledgementService</members>


### PR DESCRIPTION
Pure mechanical refactor, no behavior change. Extracts `AckStatus`, `AckOpportunityResult`, `AckDetailedResult`, and `AckEmailConfig` from `DonationAcknowledgementService` into `classes/domain/`, breaking the facade-impl circular coupling. Invocable wrapper classes stay in the facade per the InvocableMethod contract.

Phase A of [the cleanup plan](docs/plans/cleanup-refactor-1784919981/cleanup-refactor-plan.md).

Verified: prettier, eslint, jest all green. **Apex tests not yet run** - merge waits on org verification.

Also includes a one-off prettier fix for jest.config.js (pre-existing drift).

🤖 Generated with [Claude Code](https://claude.com/claude-code)