### PR TITLE
Add CumulusCI config for scratch org automation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,11 @@
 .localdevserver/
 deploy-options.json
 
+# CumulusCI
+.cci/
+test_results.json
+test_results.xml
+
 # LWC VSCode autocomplete
 **/lwc/jsconfig.json
 

--- a/cumulusci.yml
+++ b/cumulusci.yml
@@ -1,0 +1,8 @@
+project:
+  name: EnhancedDonationAck
+  package:
+    name: Enhanced Donation Acknowledgement
+    api_version: "62.0"
+  source_format: sfdx
+  dependencies:
+    - github: https://github.com/SalesforceFoundation/NPSP

--- a/docs/plans/cleanup-refactor-1784919981/cleanup-refactor-plan.md
+++ b/docs/plans/cleanup-refactor-1784919981/cleanup-refactor-plan.md
@@ -35,7 +35,7 @@ Goal: one error channel (result objects, not exceptions), per-message send resul
 
 ### Deliverables
 
-1. Change `IEmailService.sendEmail` to return `List<Messaging.SendEmailResult>` instead of `void`/throw. `EmailService` calls `Messaging.sendEmail(emails, false)` (allOrNothing = false) and returns the results unfiltered. Update `MockEmailService` to support per-message success/failure configuration (add `setPartialFailure(List<Integer> failingIndexes)` alongside the existing helpers).
+1. Change `IEmailService.sendEmail` to return `List<AckSendResult>` (new domain class: `success`, `errorMessage`) instead of `void`/throw — one result per input email, in input order. (Amended from `List<Messaging.SendEmailResult>`: Apex tests cannot construct `SendEmailResult`, and a domain type decouples us from `Messaging` anyway.) `EmailService` calls `Messaging.sendEmail(emails, false)` (allOrNothing = false) and maps the results. Update `MockEmailService` to support per-message success/failure configuration (add `setPartialFailure(...)` alongside the existing helpers).
 2. Rework `EmailSendCommand`: map each `SendEmailResult` back to its opportunity by index (results are returned in input order). Successful messages get `SUCCESS`; failed messages get `EMAIL_SEND_FAILED` with the per-message error text. Remove both `throw new AuraHandledException(...)` statements. `SendOutput` gains genuinely mixed success/failure lists.
 3. Rework `DatabaseUpdateCommand`: use `Database.update(oppsToUpdate, false)` and map per-record results. Add a new `AckStatus.ACK_UPDATE_FAILED` for records whose email sent but whose update failed, with a reason that makes clear the email DID send and the record needs manual attention. Remove the `AuraHandledException` throws. Only opportunities whose email actually sent are passed to this command.
 4. Update aggregation and counters: `AckDetailedResult` gains an `ackUpdateFailures` count; `buildSummaryMessage` and the Flow wrapper expose it; the LWC toast logic surfaces it as a warning distinct from send failures ("emails sent but N records could not be updated").
@@ -98,7 +98,7 @@ Goal: automated checks on every PR and cleanup of small inconsistencies. Can pro
 1. Donor lookup: `npsp__Primary_Contact__c` (NPSP parity). Must be validated against real org data in a sandbox before production deploy.
 2. Missing template: hard error, send nothing. No static-content mode.
 3. CI org automation: CumulusCI.
-4. Verification workflow: Apex tests run in a re-authenticated sandbox (`ackdev25` or similar) before each phase PR merges. Local checks (prettier, eslint, jest, Code Analyzer) run on every change.
+4. Verification workflow (revised 2026-07-24): Apex tests run in disposable scratch orgs created from the connected DevHub, with NPSP installed via CumulusCI (pulled forward from Phase E). Local checks (prettier, eslint, jest, Code Analyzer) run on every change. A sandbox is still needed once, before any production deploy, to validate the `npsp__Primary_Contact__c` switch against real org data — scratch orgs have no real donor records.
 
 ## Execution workflow
 

--- a/orgs/dev.json
+++ b/orgs/dev.json
@@ -1,0 +1,13 @@
+{
+  "orgName": "cu company",
+  "edition": "Developer",
+  "features": ["EnableSetPasswordInApi"],
+  "settings": {
+    "lightningExperienceSettings": {
+      "enableS1DesktopEnabled": true
+    },
+    "mobileSettings": {
+      "enableS1EncryptedStoragePref2": false
+    }
+  }
+}


### PR DESCRIPTION
Adds `cumulusci.yml` + `orgs/dev.json` so anyone can build a scratch org with the full NPSP dependency chain in one command (`cci flow run dev_org --org dev`, ~11 min) and run Apex tests (`cci task run run_tests --org dev`). Verified working today: built the org, installed NPSP 3.237, deployed, 71/71 tests passing.

Pulled forward from Phase E of the [cleanup plan](docs/plans/cleanup-refactor-1784919981/cleanup-refactor-plan.md); also records two plan amendments (scratch-org verification workflow, AckSendResult domain type).

Setup notes for fresh machines/CI: CumulusCI needs a `github` service connected (for NPSP dependency resolution) and `keyrings.alt` injected when no OS keyring exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)