### PR TITLE
Phase E: CI pipeline, Code Analyzer gating, and security housekeeping

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,175 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  # Prettier, ESLint, and LWC Jest unit tests. No org required.
+  local-checks:
+    name: Local checks (prettier, lint, unit tests)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Read Node.js version from .tool-versions
+        id: node-version
+        run: |
+          version=$(grep -E '^nodejs ' .tool-versions | awk '{print $2}')
+          echo "version=${version:-24}" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ steps.node-version.outputs.version }}
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Verify formatting (prettier)
+        run: npm run prettier:verify
+
+      - name: Lint (eslint)
+        run: npm run lint
+
+      - name: Unit tests with coverage (LWC Jest)
+        run: npm run test:unit:coverage
+
+  # Salesforce Code Analyzer (PMD/ESLint/etc.) over force-app. Fails the job on
+  # High (or more severe) findings. No org required.
+  code-analyzer:
+    name: Static analysis (Salesforce Code Analyzer)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      # The Code Analyzer "flow" engine needs Python 3.10+ on PATH to
+      # instantiate. Without it, the engine fails to load - a Critical-severity
+      # tooling error (not a code finding) that would otherwise fail this job
+      # spuriously on every run.
+      - name: Set up Python (required by the Code Analyzer "flow" engine)
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+
+      - name: Read Node.js version from .tool-versions
+        id: node-version
+        run: |
+          version=$(grep -E '^nodejs ' .tool-versions | awk '{print $2}')
+          echo "version=${version:-24}" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ steps.node-version.outputs.version }}
+
+      # No official salesforcecli/setup-cli action exists in the salesforcecli
+      # GitHub org (verified), so install the CLI directly via npm.
+      - name: Install Salesforce CLI
+        run: npm install --global @salesforce/cli
+
+      - name: Install code-analyzer plugin
+        run: sf plugins install code-analyzer@5.2.2
+
+      - name: Run Salesforce Code Analyzer
+        run: |
+          mkdir -p analysis-results
+          sf code-analyzer run \
+            --workspace force-app \
+            --view detail \
+            --severity-threshold High \
+            --output-file analysis-results/code-analyzer-results.json \
+            --output-file analysis-results/code-analyzer-results.html
+
+      - name: Upload Code Analyzer results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: code-analyzer-results
+          path: analysis-results/
+          retention-days: 30
+
+  # Secrets cannot be referenced directly in a job-level `if:` (a job whose
+  # condition depends solely on missing secrets can behave unpredictably, e.g.
+  # on forked-repo pull requests where secrets are unset). Route the check
+  # through a step that reads the secret into an env var and publishes a job
+  # output instead, then gate apex-tests on that output.
+  check-devhub-secret:
+    name: Check for DEVHUB_SFDX_AUTH_URL secret
+    runs-on: ubuntu-latest
+    outputs:
+      has_devhub: ${{ steps.check.outputs.has_devhub }}
+    steps:
+      - name: Check whether DEVHUB_SFDX_AUTH_URL secret is set
+        id: check
+        env:
+          DEVHUB_SFDX_AUTH_URL: ${{ secrets.DEVHUB_SFDX_AUTH_URL }}
+        run: |
+          if [ -n "$DEVHUB_SFDX_AUTH_URL" ]; then
+            echo "has_devhub=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_devhub=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  # Deploys to a scratch org via CumulusCI and runs the full Apex test suite.
+  # Skipped (not failed) when DEVHUB_SFDX_AUTH_URL isn't configured, e.g. on
+  # pull requests from forks. See docs/ci-setup.md for the one-time setup.
+  apex-tests:
+    name: Apex tests (scratch org via CumulusCI)
+    needs: check-devhub-secret
+    if: needs.check-devhub-secret.outputs.has_devhub == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install Salesforce CLI
+        run: npm install --global @salesforce/cli
+
+      - name: Install CumulusCI
+        run: |
+          python -m pip install --upgrade pip pipx
+          python -m pipx ensurepath
+          pipx install cumulusci
+          # CI runners have no OS keyring (no Secret Service / macOS Keychain /
+          # Windows Credential Manager), which CumulusCI's local keychain
+          # needs by default. keyrings.alt provides a file-based fallback so
+          # `cci` can store/retrieve org and service credentials headlessly.
+          pipx inject cumulusci keyrings.alt
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
+      - name: Authenticate Dev Hub
+        env:
+          DEVHUB_SFDX_AUTH_URL: ${{ secrets.DEVHUB_SFDX_AUTH_URL }}
+        run: |
+          echo "$DEVHUB_SFDX_AUTH_URL" | sf org login sfdx-url --sfdx-url-stdin --set-default-dev-hub --alias devhub
+
+      # CumulusCI needs a GitHub token to resolve the NPSP dependency
+      # (unauthenticated GitHub API calls hit a low rate limit and can fail
+      # dependency resolution). The workflow's own GITHUB_TOKEN is sufficient.
+      - name: Connect GitHub service for CumulusCI
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          cci service connect github \
+            --username "${{ github.actor }}" \
+            --email "${{ github.actor }}@users.noreply.github.com" \
+            --token "$GITHUB_TOKEN" \
+            --project
+
+      - name: Deploy and run Apex tests in a scratch org
+        run: cci flow run ci_feature --org dev --no-prompt
+
+      - name: Delete scratch org
+        if: always()
+        run: cci org scratch_delete dev

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,11 @@
 .localdevserver/
 deploy-options.json
 
+# CumulusCI
+.cci/
+test_results.json
+test_results.xml
+
 # LWC VSCode autocomplete
 **/lwc/jsconfig.json
 

--- a/README.md
+++ b/README.md
@@ -151,6 +151,17 @@ The project includes comprehensive test coverage (91%) with:
 
 Run tests with: `scripts/run_all_tests.sh`
 
+## Development
+
+### CI
+
+Every pull request and push to `main` runs formatting/lint/unit-test checks and static
+analysis (Salesforce Code Analyzer) automatically with no setup required. A third job
+deploys to a scratch org and runs the full Apex test suite via CumulusCI, but only once a
+Dev Hub secret is configured. See [`docs/ci-setup.md`](docs/ci-setup.md) for what each job
+does and the one manual step (creating the `DEVHUB_SFDX_AUTH_URL` repo secret) needed to
+enable the Apex test job.
+
 ## Notes
 
 - [How to use Flows for List View Records](https://www.accidentalcodersf.com/2020/07/use-flows-from-list-views-salesforce.html)

--- a/cumulusci.yml
+++ b/cumulusci.yml
@@ -1,0 +1,8 @@
+project:
+  name: EnhancedDonationAck
+  package:
+    name: Enhanced Donation Acknowledgement
+    api_version: "62.0"
+  source_format: sfdx
+  dependencies:
+    - github: https://github.com/SalesforceFoundation/NPSP

--- a/docs/ci-setup.md
+++ b/docs/ci-setup.md
@@ -1,0 +1,128 @@
+# CI Setup
+
+This repo runs GitHub Actions on every pull request and every push to `main`, defined in
+[`.github/workflows/ci.yml`](../.github/workflows/ci.yml).
+
+## What the workflow does
+
+### `local-checks`
+
+No org required. Checks out the repo, installs Node (version read from `.tool-versions`,
+falling back to Node 24 if that file is missing the `nodejs` line), runs `npm ci`, then:
+
+- `npm run prettier:verify` - formatting check
+- `npm run lint` - ESLint over `aura`/`lwc` JS
+- `npm run test:unit:coverage` - LWC Jest unit tests with coverage
+
+### `code-analyzer`
+
+No org required. Installs Python (needed by Code Analyzer's `flow` engine - see
+[Gotchas](#gotchas) below), installs the Salesforce CLI (`sf`) via npm, installs the
+`code-analyzer` plugin pinned to `5.2.2` (matching the version validated locally), and runs:
+
+```
+sf code-analyzer run --workspace force-app --view detail --severity-threshold High \
+  --output-file analysis-results/code-analyzer-results.json \
+  --output-file analysis-results/code-analyzer-results.html
+```
+
+`--severity-threshold High` makes the command (and therefore the job) exit non-zero if any
+Critical or High severity violation is found. Results are uploaded as a build artifact
+(`code-analyzer-results`, JSON + HTML) regardless of pass/fail, so a failure can be
+inspected without re-running locally.
+
+A handful of PMD `ApexCRUDViolation` findings are intentionally left in place and
+suppressed in code with `@SuppressWarnings('PMD.ApexCRUDViolation')` plus a comment
+explaining why (queries against `Ack_Setting__mdt`, `EmailTemplate`, and
+`OrgWideEmailAddress` - all admin-configured setup/config metadata that end users
+legitimately lack object/field permissions on; enforcing `WITH USER_MODE` there would
+break the feature for non-admin users, not make it safer). If Code Analyzer starts
+flagging genuinely new High/Critical findings, this job is the gate that catches them.
+
+### `apex-tests`
+
+Requires the `DEVHUB_SFDX_AUTH_URL` secret (see [Manual setup](#manual-setup-required)
+below). Deploys the package to a fresh scratch org via CumulusCI and runs the full Apex
+test suite (38 tests as of this writing). Steps:
+
+1. Install Python, the Salesforce CLI, and CumulusCI (via `pipx`, with the
+   `keyrings.alt` gotcha handled - see below).
+2. Authenticate the Dev Hub from the `DEVHUB_SFDX_AUTH_URL` secret
+   (`sf org login sfdx-url --sfdx-url-stdin --set-default-dev-hub`).
+3. Connect CumulusCI's `github` service using the workflow's own `GITHUB_TOKEN` (see
+   below).
+4. `cci flow run ci_feature --org dev --no-prompt` - creates the scratch org (CumulusCI
+   provisions it automatically on first use of the `dev` org name), deploys, and runs
+   Apex tests.
+5. **Always** (`if: always()`) deletes the scratch org with
+   `cci org scratch_delete dev`, even if the flow failed, so failed runs don't leak
+   scratch orgs against the Dev Hub's org limits.
+
+This job is **skipped, not failed**, when `DEVHUB_SFDX_AUTH_URL` isn't set - see
+[Manual setup](#manual-setup-required).
+
+## Manual setup required
+
+The only manual step is creating the `DEVHUB_SFDX_AUTH_URL` repository secret. Everything
+else in the workflow is self-contained.
+
+1. Authenticate a Dev Hub-enabled org locally if you haven't already (`sf org login web
+--set-default-dev-hub`).
+2. Get its SFDX auth URL:
+
+   ```
+   sf org display --verbose --target-org cuzelac@lamplighters.org
+   ```
+
+   Copy the value of **Sfdx Auth Url** from the output. (This is only shown for orgs
+   authenticated via the web login flow, not JWT.)
+
+3. In the GitHub repo: **Settings > Secrets and variables > Actions > New repository
+   secret**. Name it `DEVHUB_SFDX_AUTH_URL` and paste the URL as the value.
+
+Treat this URL as a credential - anyone with it can authenticate as your Dev Hub. Only
+store it as a GitHub Actions secret, never in a file that gets committed.
+
+Until this secret exists, `apex-tests` shows as skipped on every run; `local-checks` and
+`code-analyzer` work with no setup at all.
+
+## Gotchas
+
+- **`keyrings.alt` is required, not optional.** CumulusCI's local keychain (where it
+  stores encrypted org/service credentials between task invocations within a run) uses
+  the Python `keyring` library, which by default expects an OS-level keyring backend -
+  the Secret Service API on Linux (usually via `gnome-keyring` or a polkit agent), macOS
+  Keychain, or Windows Credential Manager. GitHub-hosted runners have none of these.
+  Without `keyrings.alt` injected into the same pipx-managed virtualenv as CumulusCI
+  (`pipx inject cumulusci keyrings.alt`), `cci` calls fail trying to reach a keyring
+  backend that doesn't exist. `keyrings.alt` provides a file-based fallback backend that
+  works headlessly.
+- **The `github` service must be connected before the flow runs, or dependency
+  resolution can fail.** `ci_feature` resolves this project's NPSP dependency
+  (`SalesforceFoundation/NPSP` on GitHub) as part of the `update_dependencies` task,
+  which means it makes GitHub API calls. Unauthenticated GitHub API requests are capped
+  at 60/hour per IP - trivial to exhaust on a shared GitHub-hosted runner pool - while
+  requests authenticated with a token get a much higher limit. The workflow's built-in
+  `GITHUB_TOKEN` (automatically provided by GitHub Actions, no secret setup needed) is
+  sufficient; it's connected with `cci service connect github --username ... --email ...
+--token "$GITHUB_TOKEN" --project` before the flow runs. `--project` scopes the
+  service to this repo's checkout rather than writing to a global config.
+- **The Code Analyzer `flow` engine needs Python 3.10+ on `PATH`.** Without it, the
+  engine fails to instantiate with a Critical-severity `UninstantiableEngineError` - a
+  tooling/environment problem, not a real finding about our code - which would fail the
+  `code-analyzer` job for the wrong reason. The workflow installs Python via
+  `actions/setup-python` before running the analyzer specifically to avoid this. (This
+  bit locally too: this repo's `.tool-versions` only pins a Node version, so a bare
+  `python3` doesn't resolve as an asdf shim unless a Python version is separately
+  selected/pinned.)
+- **`apex-tests` always deletes its scratch org**, even on failure
+  (`if: always()` on the cleanup step), because CumulusCI scratch orgs count against the
+  Dev Hub's active-scratch-org limit. A failed run that leaks orgs will eventually start
+  blocking every subsequent run until they expire or are cleaned up manually.
+- **`ci_feature` includes a couple of GitHub-writing steps** (`github_parent_pr_notes`,
+  `github_automerge_feature`) inherited from CumulusCI's universal flow definition. They
+  no-op when their preconditions aren't met (no parent PR, branch doesn't match the
+  feature-branch prefix) rather than failing the flow, but they do need a `GITHUB_TOKEN`
+  with write access to behave correctly when their preconditions _are_ met. The default
+  `GITHUB_TOKEN` has write access for same-repo pull requests; PRs from forks get a
+  read-only token, which is a known limitation if this repo ever accepts fork PRs.

--- a/force-app/main/default/classes/DonationAcknowledgementService.cls-meta.xml
+++ b/force-app/main/default/classes/DonationAcknowledgementService.cls-meta.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!-- ApexClass metadata documentation: https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_classes.htm -->
 <ApexClass xmlns="https://soap.sforce.com/2006/04/metadata">
-    <apiVersion>61.0</apiVersion>
+    <apiVersion>62.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/domain/AckContext.cls-meta.xml
+++ b/force-app/main/default/classes/domain/AckContext.cls-meta.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!-- ApexClass metadata documentation: https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_classes.htm -->
 <ApexClass xmlns="https://soap.sforce.com/2006/04/metadata">
-    <apiVersion>61.0</apiVersion>
+    <apiVersion>62.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/domain/AckDetailedResult.cls-meta.xml
+++ b/force-app/main/default/classes/domain/AckDetailedResult.cls-meta.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!-- ApexClass metadata documentation: https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_classes.htm -->
 <ApexClass xmlns="https://soap.sforce.com/2006/04/metadata">
-    <apiVersion>61.0</apiVersion>
+    <apiVersion>62.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/domain/AckEmailConfig.cls-meta.xml
+++ b/force-app/main/default/classes/domain/AckEmailConfig.cls-meta.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!-- ApexClass metadata documentation: https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_classes.htm -->
 <ApexClass xmlns="https://soap.sforce.com/2006/04/metadata">
-    <apiVersion>61.0</apiVersion>
+    <apiVersion>62.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/domain/AckOpportunityResult.cls-meta.xml
+++ b/force-app/main/default/classes/domain/AckOpportunityResult.cls-meta.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!-- ApexClass metadata documentation: https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_classes.htm -->
 <ApexClass xmlns="https://soap.sforce.com/2006/04/metadata">
-    <apiVersion>61.0</apiVersion>
+    <apiVersion>62.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/domain/AckSendResult.cls-meta.xml
+++ b/force-app/main/default/classes/domain/AckSendResult.cls-meta.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!-- ApexClass metadata documentation: https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_classes.htm -->
 <ApexClass xmlns="https://soap.sforce.com/2006/04/metadata">
-    <apiVersion>61.0</apiVersion>
+    <apiVersion>62.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/domain/AckStatus.cls-meta.xml
+++ b/force-app/main/default/classes/domain/AckStatus.cls-meta.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!-- ApexClass metadata documentation: https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_classes.htm -->
 <ApexClass xmlns="https://soap.sforce.com/2006/04/metadata">
-    <apiVersion>61.0</apiVersion>
+    <apiVersion>62.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/interfaces/IEmailService.cls-meta.xml
+++ b/force-app/main/default/classes/interfaces/IEmailService.cls-meta.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!-- ApexClass metadata documentation: https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_classes.htm -->
 <ApexClass xmlns="https://soap.sforce.com/2006/04/metadata">
-    <apiVersion>61.0</apiVersion>
+    <apiVersion>62.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/interfaces/IOrgWideEmailService.cls-meta.xml
+++ b/force-app/main/default/classes/interfaces/IOrgWideEmailService.cls-meta.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!-- ApexClass metadata documentation: https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_classes.htm -->
 <ApexClass xmlns="https://soap.sforce.com/2006/04/metadata">
-    <apiVersion>61.0</apiVersion>
+    <apiVersion>62.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/services/DonationAcknowledgementServiceImpl.cls
+++ b/force-app/main/default/classes/services/DonationAcknowledgementServiceImpl.cls
@@ -62,8 +62,15 @@ public with sharing class DonationAcknowledgementServiceImpl {
    * not observable. Blank fields on the CMT record are treated as "not configured" and
    * leave the corresponding default in place. If no active record exists, the hardcoded
    * defaults are kept as-is.
+   *
+   * Deliberately not WITH USER_MODE / no explicit CRUD/FLS check: Ack_Setting__mdt is
+   * admin-configured setup metadata (Custom Metadata Type), not user data. End users who
+   * lack Setup access to CMT records still need this configuration to resolve so they can
+   * send acknowledgements - enforcing user mode here would silently break the feature for
+   * non-admin users. Accepted PMD ApexCRUDViolation finding; see docs/ci-setup.md.
    */
   @TestVisible
+  @SuppressWarnings('PMD.ApexCRUDViolation')
   private void loadAckSettingConfig() {
     if (ackSettingConfigLoaded) {
       return;
@@ -116,6 +123,7 @@ public with sharing class DonationAcknowledgementServiceImpl {
         npsp__Acknowledgment_Status__c // Added field
       FROM Opportunity
       WHERE Id IN :idList
+      WITH USER_MODE
     ];
   }
 
@@ -278,7 +286,7 @@ public with sharing class DonationAcknowledgementServiceImpl {
       }
     }
     ctx.contactMap = new Map<Id, Contact>(
-      [SELECT Id, Email FROM Contact WHERE Id IN :contactIds]
+      [SELECT Id, Email FROM Contact WHERE Id IN :contactIds WITH USER_MODE]
     );
 
     List<Opportunity> validOpportunities = new List<Opportunity>();
@@ -443,7 +451,8 @@ public with sharing class DonationAcknowledgementServiceImpl {
 
     List<Database.SaveResult> saveResults = Database.update(
       oppsToUpdate,
-      false
+      false,
+      AccessLevel.USER_MODE
     );
 
     for (Integer i = 0; i < successfulResults.size(); i++) {
@@ -525,7 +534,14 @@ public with sharing class DonationAcknowledgementServiceImpl {
    * @return AckEmailConfig configured with the template, or null if the configured
    * template could not be found (or the lookup failed unexpectedly) - callers must
    * treat null as a hard configuration error, not fall back to any other content.
+   *
+   * Deliberately not WITH USER_MODE / no explicit CRUD/FLS check: EmailTemplate is setup
+   * metadata that the running user does not need direct object access to in order to
+   * trigger a send - Messaging.sendEmail resolves and renders the template on the user's
+   * behalf. Enforcing user mode here would break sends for users without Setup access to
+   * EmailTemplate. Accepted PMD ApexCRUDViolation finding; see docs/ci-setup.md.
    */
+  @SuppressWarnings('PMD.ApexCRUDViolation')
   private AckEmailConfig getEmailConfiguration() {
     try {
       EmailTemplate tmpl = [

--- a/force-app/main/default/classes/services/DonationAcknowledgementServiceImpl.cls
+++ b/force-app/main/default/classes/services/DonationAcknowledgementServiceImpl.cls
@@ -104,7 +104,10 @@ public with sharing class DonationAcknowledgementServiceImpl {
   }
 
   /**
-   * Shared logic to process Opportunities by Ids
+   * Shared logic to process Opportunities by Ids.
+   * Throws QueryException when the running user lacks read access to any selected field,
+   * because WITH USER_MODE enforces field-level security - callers must catch it and
+   * report a permission error rather than letting it escape as an unhandled exception.
    */
   public List<Opportunity> getOpportunitiesByIds(List<Id> idList) {
     if (idList == null || idList.isEmpty()) {
@@ -193,7 +196,16 @@ public with sharing class DonationAcknowledgementServiceImpl {
    * @return DetailedAckResult with individual opportunity tracking and aggregated counts
    */
   public AckDetailedResult sendAcknowledgementsDetailed(List<Id> idList) {
-    List<Opportunity> opps = getOpportunitiesByIds(idList);
+    List<Opportunity> opps = new List<Opportunity>();
+    try {
+      opps = getOpportunitiesByIds(idList);
+    } catch (QueryException e) {
+      // WITH USER_MODE throws when the running user lacks read access to any selected
+      // field. Report it as a per-opportunity permission error rather than letting it
+      // escape to the facade, which would collapse the whole run into one generic
+      // AuraHandledException (LWC) or a zeroed-out summary (Flow).
+      return buildAccessErrorResult(idList, e);
+    }
     if (opps.isEmpty()) {
       AckDetailedResult emptyResult = new AckDetailedResult();
       emptyResult.emailType = 'No opportunities provided';
@@ -234,6 +246,31 @@ public with sharing class DonationAcknowledgementServiceImpl {
       result.addOpportunityResult(oppResult);
     }
     result.emailType = 'Configuration error';
+    return result;
+  }
+
+  /**
+   * Build a result reporting every requested opportunity as CONFIG_ERROR because the
+   * running user lacks the object- or field-level access that WITH USER_MODE enforces.
+   * Ids are reported without names because the query that would have supplied the names
+   * is the one that failed. No emails are sent and no records are updated.
+   */
+  private AckDetailedResult buildAccessErrorResult(
+    List<Id> idList,
+    Exception e
+  ) {
+    String reason =
+      'Insufficient object or field permissions to read the donation records - ' +
+      'no emails were sent. Ask your administrator to grant access. Details: ' +
+      e.getMessage();
+
+    AckDetailedResult result = new AckDetailedResult();
+    for (Id oppId : idList) {
+      AckOpportunityResult oppResult = new AckOpportunityResult(oppId, null);
+      oppResult.setStatus(AckStatus.CONFIG_ERROR, reason);
+      result.addOpportunityResult(oppResult);
+    }
+    result.emailType = 'Permission error';
     return result;
   }
 
@@ -285,9 +322,30 @@ public with sharing class DonationAcknowledgementServiceImpl {
         contactIds.add(opp.npsp__Primary_Contact__c);
       }
     }
-    ctx.contactMap = new Map<Id, Contact>(
-      [SELECT Id, Email FROM Contact WHERE Id IN :contactIds WITH USER_MODE]
-    );
+    try {
+      ctx.contactMap = new Map<Id, Contact>(
+        [SELECT Id, Email FROM Contact WHERE Id IN :contactIds WITH USER_MODE]
+      );
+    } catch (QueryException e) {
+      // Same WITH USER_MODE contract as getOpportunitiesByIds(): a missing FLS grant on
+      // Contact.Email throws rather than nulling the field. No emails have been sent
+      // yet, so report every opportunity as a permission error and stop the pipeline
+      // cleanly - leaving contactMap empty instead would mislabel this as NO_CONTACT.
+      String reason =
+        'Insufficient object or field permissions to read the donor Contact records - ' +
+        'no emails were sent. Ask your administrator to grant access. Details: ' +
+        e.getMessage();
+      for (Opportunity opp : ctx.opportunities) {
+        AckOpportunityResult oppResult = new AckOpportunityResult(
+          opp.Id,
+          opp.Name
+        );
+        oppResult.setStatus(AckStatus.CONFIG_ERROR, reason);
+        ctx.result.addOpportunityResult(oppResult);
+      }
+      ctx.opportunities = new List<Opportunity>();
+      return;
+    }
 
     List<Opportunity> validOpportunities = new List<Opportunity>();
 
@@ -425,6 +483,10 @@ public with sharing class DonationAcknowledgementServiceImpl {
    * is marked ACK_UPDATE_FAILED rather than being silently left as SUCCESS - the email
    * already went out, so this needs manual attention to avoid a duplicate
    * acknowledgement email later.
+   *
+   * Note that AccessLevel.USER_MODE enforces CRUD/FLS before the DML runs and throws for
+   * the whole call rather than reporting per-record SaveResult errors, so that case is
+   * caught separately and folded into the same ACK_UPDATE_FAILED reporting.
    */
   private void updateRecords(AckContext ctx) {
     List<AckOpportunityResult> successfulResults = new List<AckOpportunityResult>();
@@ -449,11 +511,33 @@ public with sharing class DonationAcknowledgementServiceImpl {
       );
     }
 
-    List<Database.SaveResult> saveResults = Database.update(
-      oppsToUpdate,
-      false,
-      AccessLevel.USER_MODE
-    );
+    List<Database.SaveResult> saveResults = new List<Database.SaveResult>();
+    try {
+      saveResults = Database.update(oppsToUpdate, false, AccessLevel.USER_MODE);
+    } catch (Exception e) {
+      // AccessLevel.USER_MODE enforces CRUD/FLS as a pre-flight check that throws for
+      // the entire call regardless of allOrNothing=false, so no SaveResults come back
+      // and no per-record error is available. The emails have already gone out by this
+      // point, so every record still has to be reported as ACK_UPDATE_FAILED - letting
+      // this escape would strand successfully emailed opportunities with no
+      // acknowledgement date and no per-record signal, risking a duplicate send later.
+      for (AckOpportunityResult oppResult : successfulResults) {
+        System.debug(
+          LoggingLevel.ERROR,
+          'Database update failed under USER_MODE for Opportunity ' +
+            oppResult.opportunityId +
+            ': ' +
+            e.getMessage()
+        );
+        oppResult.setStatus(
+          AckStatus.ACK_UPDATE_FAILED,
+          'Email was sent, but record update failed: ' +
+            e.getMessage() +
+            '. Record needs manual attention to prevent duplicate acknowledgement.'
+        );
+      }
+      return;
+    }
 
     for (Integer i = 0; i < successfulResults.size(); i++) {
       AckOpportunityResult oppResult = successfulResults[i];

--- a/force-app/main/default/classes/services/DonationAcknowledgementServiceImpl.cls-meta.xml
+++ b/force-app/main/default/classes/services/DonationAcknowledgementServiceImpl.cls-meta.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!-- Documentation: https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_classes.htm -->
 <ApexClass xmlns="https://soap.sforce.com/2006/04/metadata">
-    <apiVersion>61.0</apiVersion>
+    <apiVersion>62.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/services/EmailService.cls-meta.xml
+++ b/force-app/main/default/classes/services/EmailService.cls-meta.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!-- ApexClass metadata documentation: https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_classes.htm -->
 <ApexClass xmlns="https://soap.sforce.com/2006/04/metadata">
-    <apiVersion>61.0</apiVersion>
+    <apiVersion>62.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/services/OrgWideEmailService.cls
+++ b/force-app/main/default/classes/services/OrgWideEmailService.cls
@@ -2,6 +2,14 @@
  * Default implementation of IOrgWideEmailService
  */
 public inherited sharing class OrgWideEmailService implements IOrgWideEmailService {
+  /**
+   * Deliberately not WITH USER_MODE / no explicit CRUD/FLS check: OrgWideEmailAddress is
+   * org setup metadata, not user data - end users legitimately lack direct object access
+   * to it but still need this lookup to resolve so acknowledgement emails can be sent
+   * from the org-wide address. Enforcing user mode here would break sends for non-admin
+   * users. Accepted PMD ApexCRUDViolation finding; see docs/ci-setup.md.
+   */
+  @SuppressWarnings('PMD.ApexCRUDViolation')
   public OrgWideEmailAddress getDefaultNoReplyAddress() {
     List<OrgWideEmailAddress> addresses = [
       SELECT Id, Purpose
@@ -17,6 +25,12 @@ public inherited sharing class OrgWideEmailService implements IOrgWideEmailServi
    * Look up an OrgWideEmailAddress by its exact Address value, as configured via
    * Ack_Setting__mdt.Org_Wide_Email_Address__c. Returns null if no such address exists.
    */
+  /**
+   * Deliberately not WITH USER_MODE / no explicit CRUD/FLS check: see
+   * getDefaultNoReplyAddress() above - same rationale applies to this lookup. Accepted
+   * PMD ApexCRUDViolation finding; see docs/ci-setup.md.
+   */
+  @SuppressWarnings('PMD.ApexCRUDViolation')
   public OrgWideEmailAddress getByAddress(String address) {
     if (String.isBlank(address)) {
       return null;

--- a/force-app/main/default/classes/services/OrgWideEmailService.cls-meta.xml
+++ b/force-app/main/default/classes/services/OrgWideEmailService.cls-meta.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!-- ApexClass metadata documentation: https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_classes.htm -->
 <ApexClass xmlns="https://soap.sforce.com/2006/04/metadata">
-    <apiVersion>61.0</apiVersion>
+    <apiVersion>62.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/tests/DonationAcknowledgementServiceTest.cls-meta.xml
+++ b/force-app/main/default/classes/tests/DonationAcknowledgementServiceTest.cls-meta.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!-- ApexClass metadata documentation: https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_classes.htm -->
 <ApexClass xmlns="https://soap.sforce.com/2006/04/metadata">
-    <apiVersion>61.0</apiVersion>
+    <apiVersion>62.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/tests/mocks/MockEmailService.cls
+++ b/force-app/main/default/classes/tests/mocks/MockEmailService.cls
@@ -2,7 +2,7 @@
  * Mock implementation of IEmailService for testing
  */
 @isTest
-public class MockEmailService implements IEmailService {
+public with sharing class MockEmailService implements IEmailService {
   private Boolean successful = true;
   private String errorMessage;
   private Set<Integer> failingIndexes;

--- a/force-app/main/default/classes/tests/mocks/MockEmailService.cls-meta.xml
+++ b/force-app/main/default/classes/tests/mocks/MockEmailService.cls-meta.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!-- ApexClass metadata documentation: https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_classes.htm -->
 <ApexClass xmlns="https://soap.sforce.com/2006/04/metadata">
-    <apiVersion>61.0</apiVersion>
+    <apiVersion>62.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/tests/mocks/MockOrgWideEmailService.cls
+++ b/force-app/main/default/classes/tests/mocks/MockOrgWideEmailService.cls
@@ -1,7 +1,7 @@
 /**
  * Mock implementation of IOrgWideEmailService for testing
  */
-public class MockOrgWideEmailService implements IOrgWideEmailService {
+public with sharing class MockOrgWideEmailService implements IOrgWideEmailService {
   private OrgWideEmailAddress mockAddress;
   private OrgWideEmailAddress mockAddressByAddress;
   private Integer callCount = 0;

--- a/force-app/main/default/classes/tests/mocks/MockOrgWideEmailService.cls-meta.xml
+++ b/force-app/main/default/classes/tests/mocks/MockOrgWideEmailService.cls-meta.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!-- ApexClass metadata documentation: https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_classes.htm -->
 <ApexClass xmlns="https://soap.sforce.com/2006/04/metadata">
-    <apiVersion>61.0</apiVersion>
+    <apiVersion>62.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/tests/services/DonationAcknowledgementServiceImplTest.cls-meta.xml
+++ b/force-app/main/default/classes/tests/services/DonationAcknowledgementServiceImplTest.cls-meta.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!-- See: https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_classes.htm -->
 <ApexClass xmlns="https://soap.sforce.com/2006/04/metadata">
-    <apiVersion>60.0</apiVersion>
+    <apiVersion>62.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/tests/utils/AcknowledgementTestUtils.cls
+++ b/force-app/main/default/classes/tests/utils/AcknowledgementTestUtils.cls
@@ -3,7 +3,7 @@
  * Provides common test data creation, query helpers, and assertion methods across all test classes
  */
 @isTest
-public class AcknowledgementTestUtils {
+public with sharing class AcknowledgementTestUtils {
   // ===== TEST DATA CREATION METHODS =====
 
   /**

--- a/force-app/main/default/flows/Enhanced_Donation_Acknowledgement.flow-meta.xml
+++ b/force-app/main/default/flows/Enhanced_Donation_Acknowledgement.flow-meta.xml
@@ -20,7 +20,7 @@
         <nameSegment>DonationAcknowledgementService</nameSegment>
         <storeOutputAutomatically>true</storeOutputAutomatically>
     </actionCalls>
-    <apiVersion>63.0</apiVersion>
+    <apiVersion>62.0</apiVersion>
     <assignments>
         <description
     >Concatenate the values of &apos;ids&apos; and &apos;recordId&apos; into &apos;allIds&apos;</description>

--- a/force-app/main/default/lwc/acknowledgeDonationButton/acknowledgeDonationButton.js-meta.xml
+++ b/force-app/main/default/lwc/acknowledgeDonationButton/acknowledgeDonationButton.js-meta.xml
@@ -3,7 +3,7 @@
     See: https://developer.salesforce.com/docs/component-library/documentation/en/lwc/lwc.reference_configuration_tags
 -->
 <LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>60.0</apiVersion>
+    <apiVersion>62.0</apiVersion>
     <isExposed>true</isExposed>
     <targets>
         <target>lightning__RecordPage</target>

--- a/orgs/dev.json
+++ b/orgs/dev.json
@@ -1,0 +1,13 @@
+{
+  "orgName": "cu company",
+  "edition": "Developer",
+  "features": ["EnableSetPasswordInApi"],
+  "settings": {
+    "lightningExperienceSettings": {
+      "enableS1DesktopEnabled": true
+    },
+    "mobileSettings": {
+      "enableS1EncryptedStoragePref2": false
+    }
+  }
+}


### PR DESCRIPTION
Stacked on #17. Final phase of the cleanup plan.

- **CI** (.github/workflows/ci.yml): local checks (prettier/eslint/jest), Salesforce Code Analyzer failing on High severity, and scratch-org Apex tests via CumulusCI — gated to skip (not fail) until the `DEVHUB_SFDX_AUTH_URL` secret exists; one-time setup documented in [docs/ci-setup.md](docs/ci-setup.md). Scratch org always deleted, even on failure.
- **Static analysis**: 240 findings triaged; all Critical/High resolved (USER_MODE on Opportunity/Contact reads and the Opportunity update; documented suppressions on the three intentional system-mode config-object queries).
- **Housekeeping**: explicit sharing on every class; API versions unified at 62.0.

Verified in scratch org: **38/38 Apex, 9/9 jest**; `sf code-analyzer run --severity-threshold High` exits clean. The workflow itself can't execute pre-merge — each step's syntax and failure mode was verified locally instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)